### PR TITLE
Remove framedelay

### DIFF
--- a/VL.ShadowCatcher.vl
+++ b/VL.ShadowCatcher.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PMvFqWqqs1yLAVbmX0v45S" LanguageVersion="2023.5.2" Version="0.128">
-  <NugetDependency Id="FLSt9h7XMOdP0rpAwkKKWN" Location="VL.CoreLib" Version="2023.5.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="PMvFqWqqs1yLAVbmX0v45S" LanguageVersion="2023.5.0" Version="0.128">
+  <NugetDependency Id="FLSt9h7XMOdP0rpAwkKKWN" Location="VL.CoreLib" Version="2023.5.0" />
   <Patch Id="DNfGMPEryrQMEAdBnh05hI">
     <Canvas Id="EOi0XkRdXSvL66Ap5PM9WU" DefaultCategory="ShadowCatcher" CanvasType="FullCategory">
       <!--
@@ -1449,7 +1449,7 @@
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="573,3255,87,19" Id="OLW7oXYcfW4LScIvCeScAW">
+            <Node Bounds="573,3255,87,26" Id="OLW7oXYcfW4LScIvCeScAW">
               <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="ShadowCatcherData" />
@@ -1934,8 +1934,8 @@
         </p:NodeReference>
         <Patch Id="NhQUm5U58nLLIfFbdpubeS">
           <Canvas Id="TGNklbSH9OhM4EJKQNyrwO" CanvasType="Group">
-            <Node Bounds="597,783,425,19" Id="DgAHJyaAZ0nMsQul22FQ6Y">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (D:\Documents\Dev\VL.ShadowCatcher)">
+            <Node Bounds="450,687,425,19" Id="DgAHJyaAZ0nMsQul22FQ6Y">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
               </p:NodeReference>
@@ -1963,7 +1963,7 @@
               <Pin Id="JEf5vaZGQ8nPA25s4XvLvI" Name="Parameter Setter" Kind="InputPin" />
               <Pin Id="GBNx5659KUdLdYu4i3xTph" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="641,907,165,19" Id="GCISEKXwL3VQDoGt8CFiNd">
+            <Node Bounds="632,870,165,19" Id="GCISEKXwL3VQDoGt8CFiNd">
               <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
@@ -1979,7 +1979,7 @@
               <Pin Id="OccuUB9iC4RQJ0pzNy9W7S" Name="Draw Count" Kind="InputPin" />
               <Pin Id="L6b8LqybzPRPX7usAPjQs4" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="655,1015,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
+            <Node Bounds="635,1105,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
               <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
@@ -1995,7 +1995,7 @@
               <Pin Id="ChfH4QpRGwHLciNOwh20Oy" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="PsNo2ehteioPThgMNATyIa" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="656,831,67,19" Id="I4FAhFoJWEmOFvkj2IBsah">
+            <Node Bounds="647,794,67,19" Id="I4FAhFoJWEmOFvkj2IBsah">
               <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
@@ -2003,7 +2003,7 @@
               </p:NodeReference>
               <Pin Id="OiKnGW1d0shPoP17tDHr5L" Name="Alpha Blend" Kind="OutputPin" />
             </Node>
-            <Node Bounds="780,643,46,19" Id="IyA4nxuTBiYMnyia6ixVYH">
+            <Node Bounds="633,547,46,19" Id="IyA4nxuTBiYMnyia6ixVYH">
               <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -2013,7 +2013,7 @@
               <Pin Id="AOaBgMQtSiuOrYEGbjvfnF" Name="Y" Kind="InputPin" />
               <Pin Id="UDuUF5jhGclM7P6DgBylXb" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="808,693,25,19" Id="DbUlhef6e8sQDPDo2f988d">
+            <Node Bounds="661,597,25,19" Id="DbUlhef6e8sQDPDo2f988d">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="/" />
@@ -2022,7 +2022,7 @@
               <Pin Id="QMfEPP9CnMgPYwrK3ZGtw7" Name="Input 2" Kind="InputPin" />
               <Pin Id="G1ABsRYsM8KPiE1tHN8j4J" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="617,723,165,19" Id="OjTRCgxnr9FNwBe8zSUWbd">
+            <Node Bounds="470,627,165,19" Id="OjTRCgxnr9FNwBe8zSUWbd">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -2039,18 +2039,18 @@
               <Pin Id="LZamEdTC3UNOL33w2Cdw0R" Name="Result 8" Kind="OutputPin" />
               <Pin Id="Q4bhyaIzlxuNSK3BfgYXYV" Name="Result 9" Kind="OutputPin" />
             </Node>
-            <Pad Id="GGYIPMJR3I1MZnPhAkIOlN" Comment="Cascade Count" Bounds="906,740,35,15" ShowValueBox="true" isIOBox="true" Value="4">
+            <Pad Id="GGYIPMJR3I1MZnPhAkIOlN" Comment="Cascade Count" Bounds="759,644,35,15" ShowValueBox="true" isIOBox="true" Value="4">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
-            <ControlPoint Id="HwscKIVZENNM6aHdKWSBrx" Bounds="584,294" />
-            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="789,877" />
-            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="1008,577" />
-            <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="662,1073" />
-            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="1057,642" />
-            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="881,988" />
-            <Node Bounds="582,348,414,26" Id="HfHLZKluYWxL9GZIgoIaFq">
+            <ControlPoint Id="HwscKIVZENNM6aHdKWSBrx" Bounds="437,198" />
+            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="780,840" />
+            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="1128,400" />
+            <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="639,1192" />
+            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="1177,465" />
+            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="1194,1011" />
+            <Node Bounds="435,252,414,26" Id="HfHLZKluYWxL9GZIgoIaFq">
               <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
@@ -2064,7 +2064,7 @@
               <Pin Id="Nlx4svqScr5NETl9REihzk" Name="Spot Light Count" Kind="OutputPin" />
               <Pin Id="Cgr6BvGeDWSOPzqXn8Adto" Name="Point Light Count" Kind="OutputPin" />
             </Node>
-            <Node Bounds="526,472,80,80" Id="TW21N9564SxMLYf8UydRmz">
+            <Node Bounds="378,376,80,80" Id="TW21N9564SxMLYf8UydRmz">
               <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AvoidNull" />
@@ -2073,10 +2073,10 @@
               <Pin Id="PMyuvdLo5cLQKT1bQnqqJn" Name="Output" Kind="OutputPin" />
               <Patch Id="ObVgMZW6E0oO9UXCyr1OdK" Name="Create Default Value" ManuallySortedPins="true">
                 <Pin Id="K3Bi609n5ojQIerUjhpOXS" Name="Result" Kind="OutputPin" />
-                <ControlPoint Id="M1bLTuV0yFZLwUJQMjT16L" Bounds="542,523" />
+                <ControlPoint Id="M1bLTuV0yFZLwUJQMjT16L" Bounds="395,427" />
               </Patch>
             </Node>
-            <Node Bounds="541,436,106,19" Id="U7sUUMjZBR3LUBhntuNdxf">
+            <Node Bounds="394,340,106,19" Id="U7sUUMjZBR3LUBhntuNdxf">
               <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
@@ -2087,7 +2087,7 @@
               <Pin Id="DPt1iU8vGrAOksjJXBvt5s" Name="Output" Kind="OutputPin" />
               <Pin Id="Qbi9TaW83k4N6aZm6zgeRk" Name="Has Changed" Kind="OutputPin" />
             </Node>
-            <Node Bounds="525,575,44,26" Id="UKjNgfVDyG1NBXj6J2W7fD">
+            <Node Bounds="378,479,44,26" Id="UKjNgfVDyG1NBXj6J2W7fD">
               <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Texture" />
@@ -2097,14 +2097,14 @@
               <Pin Id="AyNYTehgFhlLEfc0qS7Zmk" Name="Output" Kind="StateOutputPin" />
               <Pin Id="SEzoPXakqNYPKFOsgukg4K" Name="Width" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="DA6h5rwBNC6LAYYfmSnpOd" Bounds="528,396" />
-            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="979,541" />
-            <Pad Id="QsVP4LdMemMOdVYurFDgKb" Comment="Width" Bounds="780,615,35,15" ShowValueBox="true" isIOBox="true" />
-            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="785,950" />
-            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="834,970" />
-            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="764,856" />
-            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="744,840" />
-            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="1032,610" />
+            <ControlPoint Id="DA6h5rwBNC6LAYYfmSnpOd" Bounds="381,300" />
+            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="1099,364" />
+            <Pad Id="QsVP4LdMemMOdVYurFDgKb" Comment="Width" Bounds="633,519,35,15" ShowValueBox="true" isIOBox="true" />
+            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="1098,973" />
+            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="1147,993" />
+            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="755,819" />
+            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="735,803" />
+            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="1152,433" />
           </Canvas>
           <ProcessDefinition Id="OYIyatA91KLOCZaTdgqMhW">
             <Fragment Id="AM3gkuf1OjILQKsjuNe11b" Patch="TZOUr2B4xdnNuWwnWeWSzU" Enabled="true" />
@@ -2508,6 +2508,482 @@
             </Patch>
           </Patch>
         </Node>
+        <!--
+
+    ************************ ShadowCatcherRenderer ************************
+
+-->
+        <Node Name="ShadowCatcherRenderer" Bounds="527,662" Id="MKIwYc0GMvhM1Xi97B8Ofx">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ClassDefinition" Name="Class" />
+          </p:NodeReference>
+          <p:Interfaces>
+            <TypeReference LastCategoryFullName="Stride.API.Rendering" LastDependency="VL.Stride.vl">
+              <Choice Kind="MutableInterfaceType" Name="IRenderer" />
+            </TypeReference>
+          </p:Interfaces>
+          <Patch Id="QejBHbOpLTJOuzZIrA4NNY">
+            <Canvas Id="LLYUbQWfLcmPsoyV9K3uVm" CanvasType="Group">
+              <ControlPoint Id="JmyUN95v58lQDkwdKK7ZxQ" Bounds="742,651" />
+              <Node Bounds="1326,975,425,19" Id="HiRC7axjnA7POHvVuRF9BX">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
+                </p:NodeReference>
+                <Pin Id="LjRcLyRYjQTL6r2G72U1Dx" Name="Shadow Map Texture" Kind="InputPin" />
+                <Pin Id="Pmkk6PyrSbTNH1gW8CJpo1" Name="World To Shadow Cascade UV" Kind="InputPin" />
+                <Pin Id="M1eEJ77dUeNLO60zHhtL54" Name="Depth Biases" Kind="InputPin" />
+                <Pin Id="JOd7Yv1YpGELNrmDCV4gkO" Name="Offset Scales" Kind="InputPin" />
+                <Pin Id="MnIrnhAhFEhLfmc9iOtcyz" Name="Light Positions" Kind="InputPin" />
+                <Pin Id="ML895Ub6iwHMn6bY2qWHrC" Name="Atten Params" Kind="InputPin" />
+                <Pin Id="F8JhmocSEZBQPpciz0Gnvp" Name="Filter Size" Kind="InputPin" />
+                <Pin Id="IJkUUH6AV6oNyYyM3wfyLG" Name="Cascade Depth Splits" Kind="InputPin" />
+                <Pin Id="VHFY2zPYpWCNheQDczgdTm" Name="Spot Directions" Kind="InputPin" />
+                <Pin Id="MSgrm4PPCcGPrkethMgFSR" Name="Depth Parameters" Kind="InputPin" />
+                <Pin Id="NvF8gz0v0IYLDQ7gkqwtIM" Name="Shadow Map Texture Size" Kind="InputPin" />
+                <Pin Id="FenyPqc0zkhQQIHwsmTJWp" Name="Shadow Map Texture Texel Size" Kind="InputPin" />
+                <Pin Id="C46kWyP2J4ZPjmm981rMAj" Name="Directional Count" Kind="InputPin" />
+                <Pin Id="UHghVFLFfyCLGyz7aWCD1O" Name="Spot Light Count" Kind="InputPin" />
+                <Pin Id="JgC6MYbxlS1QDdHNbi7qnI" Name="Point Light Count" Kind="InputPin" />
+                <Pin Id="B6WSt3TnXvuO2BChyS63KG" Name="Cascade Count" Kind="InputPin" />
+                <Pin Id="IeIhDGc3Q7zQFT4up5opPS" Name="Light Attenuation" Kind="InputPin" />
+                <Pin Id="LYn95tX8ihVN2Inzz6D3Ca" Name="Linear Clamp Compare Less Equal Sampler" Kind="InputPin" />
+                <Pin Id="Jn4MQIq2375PYWwPp3dQCK" Name="Color Input" Kind="InputPin" />
+                <Pin Id="Qyj9y0GuanDMZvhmuxv0qE" Name="Normal Offset" Kind="InputPin" />
+                <Pin Id="Lebv8mH06wrLu5c14Xg9E8" Name="World" Kind="InputPin" />
+                <Pin Id="CZghCSXIZpMPEgaYLrHp5e" Name="Parameter Setter" Kind="InputPin" />
+                <Pin Id="FydGgPzgtFQMI8PHwIModE" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1508,1158,165,19" Id="O16OLBOTXc2O9wT6AgeU5L">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
+                </p:NodeReference>
+                <Pin Id="UqLSa6HalcQL1GQmP9UoAo" Name="Effect Instance" Kind="InputPin" />
+                <Pin Id="MxnYiw6f9JDLwlj10swonE" Name="Blend State" Kind="InputPin" />
+                <Pin Id="VZqR9o8TNZgPCS6vWCNmVt" Name="Rasterizer State" Kind="InputPin" />
+                <Pin Id="VbZkiWB0WXvQDRKRAx2DcX" Name="Depth Stencil State" Kind="InputPin" />
+                <Pin Id="JbsV0gC5MRfPbuZHQlGdma" Name="Mesh" Kind="InputPin" />
+                <Pin Id="MFXRzNKSnUnMMuP7imHhdB" Name="Instance Count" Kind="InputPin" />
+                <Pin Id="IwwJ7FLkXDIO9nXOlCQs0I" Name="Profiling Name" Kind="InputPin" DefaultValue="Shadow Catcher" />
+                <Pin Id="M7FFE9A2gvwPu7gCm1yGAy" Name="Topology" Kind="InputPin" />
+                <Pin Id="PyHZeU4vRa2MUxo0cLUmU9" Name="Draw Count" Kind="InputPin" />
+                <Pin Id="A4HO3ad8iuwOGSNse4CpzN" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="1528,1063,67,19" Id="HZI66h2CFGJO6KHdbyPnoj">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="AlphaBlend" />
+                </p:NodeReference>
+                <Pin Id="EyJOvglCgX4MLBxyCiudK5" Name="Alpha Blend" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1509,835,46,19" Id="Mf3napswkKxOjB36yyVzgK">
+                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                </p:NodeReference>
+                <Pin Id="BjiBk8NXp8HL2hj8ydkah3" Name="X" Kind="InputPin" />
+                <Pin Id="HkwusbOBxEPPHsUPLlB6W4" Name="Y" Kind="InputPin" />
+                <Pin Id="QWaF7FGYuNpL5g5oIvn1lD" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="1537,885,25,19" Id="DMZFjfgRhQOL7KoBxIaffo">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="/" />
+                </p:NodeReference>
+                <Pin Id="SPtLlCwHO49OJk18BDwb5K" Name="Input" Kind="InputPin" DefaultValue="1, 1" />
+                <Pin Id="HNJidM6gci3NKD1G9rB5vy" Name="Input 2" Kind="InputPin" />
+                <Pin Id="NHR2FXylqiTN8BvDCvrKcQ" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1331,908,165,19" Id="EiMrjEfcNZ4NJ8X6Zyhhb5">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Decons" />
+                </p:NodeReference>
+                <Pin Id="VcGjpTTBObDOKYcGzyybau" Name="Input" Kind="StateInputPin" />
+                <Pin Id="S3Bwc27bLxgPYEOP1Q7Ljv" Name="Result" Kind="OutputPin" />
+                <Pin Id="ESh5XkMzKl7M6Eq35hGpb6" Name="Result 2" Kind="OutputPin" />
+                <Pin Id="HSMu4yNkdvJM58B7eGAjbg" Name="Result 3" Kind="OutputPin" />
+                <Pin Id="N4ba85Pr9LyOBHampi4L7u" Name="Result 4" Kind="OutputPin" />
+                <Pin Id="KgclaBeMwdbPWj3NF7TSN5" Name="Result 5" Kind="OutputPin" />
+                <Pin Id="MbevPEfTVHiQEJmaQRQzTc" Name="Result 6" Kind="OutputPin" />
+                <Pin Id="TylSnZ7ElCDNiTNQROZc85" Name="Result 7" Kind="OutputPin" />
+                <Pin Id="UdxrbsIVK34O08hANLhXh7" Name="Result 8" Kind="OutputPin" />
+                <Pin Id="CNnpVviRFLVPLLghhCEE7I" Name="Result 9" Kind="OutputPin" />
+              </Node>
+              <Pad Id="UPRhXxkWLm2LnaT2ThYJ7T" Comment="Cascade Count" Bounds="1724,759,35,15" ShowValueBox="true" isIOBox="true" Value="4">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pad>
+              <ControlPoint Id="GNgJFHqWapoQPIVfRJVXKG" Bounds="2148,968" />
+              <ControlPoint Id="P33MTf6WnozOM7eGhYzilR" Bounds="2004,688" />
+              <ControlPoint Id="KnJ7LEIBAhZNYQIrH10z9G" Bounds="2053,753" />
+              <Node Bounds="1288,522,414,26" Id="OnzPbiWgADvOpmeUJ0iwIk">
+                <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Split" />
+                </p:NodeReference>
+                <Pin Id="S4RmSRix1a2QEzvmU0gCJe" Name="Input" Kind="StateInputPin" />
+                <Pin Id="ImUNHAKmzPkOVSLVP6Lmoz" Name="Output" Kind="OutputPin" />
+                <Pin Id="K9myjgkNuMINrrZf5U7PWd" Name="ShadowMap" Kind="OutputPin" />
+                <Pin Id="AeiWyUQBxrhMEeWH0OiD3Z" Name="Buffers" Kind="OutputPin" />
+                <Pin Id="C1dvIEE1BPNLNdYb9LLfXV" Name="Directional Light Count" Kind="OutputPin" />
+                <Pin Id="DDq9NtmWIibMZimyUepMV5" Name="Spot Light Count" Kind="OutputPin" />
+                <Pin Id="IvG0KdoQ9rGMCfgUN0lZZp" Name="Point Light Count" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1254,664,80,80" Id="RBYNd2JYYt2OOsi9mZA4vr">
+                <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
+                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="AvoidNull" />
+                </p:NodeReference>
+                <Pin Id="BWHwNwXZv8XLuou0kSbaNq" Name="Input" Kind="InputPin" />
+                <Pin Id="VYRAoytJKcLL0HJXs4Qiza" Name="Output" Kind="OutputPin" />
+                <Patch Id="AJpGJ3rQZRzPEPMd5AwV87" Name="Create Default Value" ManuallySortedPins="true">
+                  <Pin Id="DNSzEhF4osKLfQWAcHXRsp" Name="Result" Kind="OutputPin" />
+                  <ControlPoint Id="ELmLkHRLBD2PdkDWkgt8PD" Bounds="1271,715" />
+                </Patch>
+              </Node>
+              <Node Bounds="1270,628,106,19" Id="TbeLnAI9epEMewgaYlQTyc">
+                <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
+                </p:NodeReference>
+                <Pin Id="S6c3293nwxTLCPZJq7td06" Name="Size" Kind="InputPin" DefaultValue="4, 4" />
+                <Pin Id="Hjhl7jv7TMjPYnEv7t00h4" Name="Format" Kind="InputPin" />
+                <Pin Id="GWUm8coql11PjX5BxbpR2U" Name="Recreate" Kind="InputPin" />
+                <Pin Id="GWfO7Gwma58MbJ7GvPQlMw" Name="Output" Kind="OutputPin" />
+                <Pin Id="IqsR10P6GLoOtN5Tx0YMWa" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1254,767,44,26" Id="Vwy3lsCZr1mPeAkw8OuXEs">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Texture" />
+                  <Choice Kind="OperationCallFlag" Name="Width" />
+                </p:NodeReference>
+                <Pin Id="MIXSTF2wBmTLXbIKJ05UbT" Name="Input" Kind="StateInputPin" />
+                <Pin Id="K76lTijzjZZQRXcbGnQyMk" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="KoGLpmJGmNuMBVCYJqJuOj" Name="Width" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="KHWIEvYfRBfQCDhdvjZsy1" Bounds="1257,588" />
+              <ControlPoint Id="I1KCXRFlc56LhwEiPPZp2E" Bounds="1975,652" />
+              <Pad Id="QsDNnDvS7AVQZBcL37Pe5y" Comment="Width" Bounds="1509,807,35,15" ShowValueBox="true" isIOBox="true" />
+              <ControlPoint Id="TUahzGGrtU2MVOcrUXDgvJ" Bounds="2123,947" />
+              <ControlPoint Id="NKbckpPLKfhONKlyJh6FV1" Bounds="2103,931" />
+              <ControlPoint Id="Hm26lRA6GDkPzesjqTsn95" Bounds="2028,721" />
+              <Node Bounds="1509,1377,51,26" Id="DEUUMoIDhvAPsnwDvyKYTm">
+                <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
+                  <Choice Kind="OperationCallFlag" Name="Draw" />
+                </p:NodeReference>
+                <Pin Id="QlK5slwNHftPF4bdWHCAQV" Name="Input" Kind="StateInputPin" />
+                <Pin Id="NEO6q6I2i4dPjNnJzhLmGp" Name="Context" Kind="InputPin" />
+                <Pin Id="Tl7wyt0Ir8sN0xW7rB3ris" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="1509,1246,188,19" Id="G8lwX9IFfNoLHDSicinMhq">
+                <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ShadowCatcherDataRetrieverRenderer" />
+                </p:NodeReference>
+                <Pin Id="VvuHJ5p18gULslOclbpmIx" Name="Input" Kind="InputPin" />
+                <Pin Id="KyVTw1RqX3ALxmTZosnBz0" Name="Output" Kind="OutputPin" />
+                <Pin Id="EdNY9C5tIlFN2EvkvaKpM1" Name="Compositor" Kind="InputPin" />
+              </Node>
+              <ControlPoint Id="Mhiump7lQ2KMyc8fto6ghL" Bounds="1922,1161" />
+            </Canvas>
+            <Patch Id="ErKdFlYsLL3LcRT3hAojhq" Name="Create" />
+            <!--
+
+    ************************  ************************
+
+-->
+            <ProcessDefinition Id="HEQMCiBtPVQN8E2zjQVxJQ" IsHidden="true">
+              <Fragment Id="E3HWjWwixOvNhAbDWqe5bc" Patch="ErKdFlYsLL3LcRT3hAojhq" Enabled="true" />
+              <Fragment Id="H1Ms8wFsY5uNLvTk3UkyOd" Patch="Jqk0aKHvQsjQJS2JGTHBEe" />
+              <Fragment Id="LV3bwxoZvanLyBjni9vOWo" Patch="KC6ZqrN2eEUPAVDVcZmkMW" Enabled="true" />
+              <Fragment Id="JRQxFXVK1S3Lop1frru2hV" Patch="CvcVK2UQo4YNiSlVGvjgTI" />
+              <Fragment Id="RzQWYRNkFTHL88HbWNTgWj" Patch="FnmgjOKJhWRMpYSMAlFN6q" />
+            </ProcessDefinition>
+            <Patch Id="Jqk0aKHvQsjQJS2JGTHBEe" Name="Draw" ParticipatingElements="OnzPbiWgADvOpmeUJ0iwIk,Vuq7FQKMqr2NIYjzTeJ7kR,RTQOzG3u3zOP3iufTDceOG,OkRdYOAhN7TOIQCtO8KxE2,HWdOVVwN8ZWP6DqIBHj1OV">
+              <Pin Id="H5CWmZ9XDPaLek5JhguQ2f" MergeId="45458" Name="Context" Kind="InputPin" />
+            </Patch>
+            <Link Id="PAdZQhTXVprNvbDTEUttYc" Ids="H5CWmZ9XDPaLek5JhguQ2f,JmyUN95v58lQDkwdKK7ZxQ" IsHidden="true" />
+            <Patch Id="KC6ZqrN2eEUPAVDVcZmkMW" Name="Update" ManuallySortedPins="true">
+              <Pin Id="Cd6rUUbI8krNp4BatW8pcH" MergeId="1345" Name="Transformation" Kind="InputPin" Bounds="324,566" />
+              <Pin Id="KXnN18wv9OjPIqttmqtrtx" MergeId="1338" Name="Mesh" Kind="InputPin" Bounds="760,474" />
+              <Pin Id="QnqWTcFPzeaOlIWK6DFZNV" MergeId="1367" Name="Light Attenuation" Kind="InputPin" Bounds="1012,495" DefaultValue="True">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="GcUuVnKqTiWMr16N6YNCZZ" MergeId="1340" Name="Shadow Color" Kind="InputPin" Bounds="917,528" />
+              <Pin Id="UuLDUc3sIMoLbVe9BfV48G" MergeId="1368" Name="Normal Offset" Kind="InputPin" Bounds="1002,557" Visibility="Optional" />
+              <Pin Id="SMq7r9CyGtXLfPKVO9mvcs" Name="Compositor" Kind="InputPin" />
+            </Patch>
+            <Patch Id="CvcVK2UQo4YNiSlVGvjgTI" Name="SetDepthStencilState">
+              <Pin Id="OUBgRBGTroCP2CqMmjxpq1" MergeId="1384" Name="Depth Stencil State" Kind="InputPin" Visibility="Optional" />
+            </Patch>
+            <Patch Id="FnmgjOKJhWRMpYSMAlFN6q" Name="SetRasterizerState">
+              <Pin Id="OB1VEuJaHTRQR5UWJd9DKc" MergeId="1387" Name="Rasterizer State" Kind="InputPin" Visibility="Optional" />
+            </Patch>
+            <Link Id="CQtOASSwbSdNTjKefzJNBH" Ids="QWaF7FGYuNpL5g5oIvn1lD,HNJidM6gci3NKD1G9rB5vy" />
+            <Link Id="Vuq7FQKMqr2NIYjzTeJ7kR" Ids="QWaF7FGYuNpL5g5oIvn1lD,NvF8gz0v0IYLDQ7gkqwtIM" />
+            <Link Id="RTQOzG3u3zOP3iufTDceOG" Ids="NHR2FXylqiTN8BvDCvrKcQ,FenyPqc0zkhQQIHwsmTJWp" />
+            <Link Id="P20HPHeBafpMVNUOGQoXNr" Ids="S3Bwc27bLxgPYEOP1Q7Ljv,Pmkk6PyrSbTNH1gW8CJpo1" />
+            <Link Id="GDt5uQvSpBJMBaSTCpu4uI" Ids="ESh5XkMzKl7M6Eq35hGpb6,M1eEJ77dUeNLO60zHhtL54" />
+            <Link Id="IyL8A97CSYxPHAZiDsZhxT" Ids="HSMu4yNkdvJM58B7eGAjbg,JOd7Yv1YpGELNrmDCV4gkO" />
+            <Link Id="FamRLHYs7svMoYJK4mcXCy" Ids="UPRhXxkWLm2LnaT2ThYJ7T,B6WSt3TnXvuO2BChyS63KG" />
+            <Link Id="F5ZFEbsPQ4PP6ZSXSBRY9b" Ids="GNgJFHqWapoQPIVfRJVXKG,JbsV0gC5MRfPbuZHQlGdma" />
+            <Link Id="Ao970gB8cVTLsypDG93r3v" Ids="KXnN18wv9OjPIqttmqtrtx,GNgJFHqWapoQPIVfRJVXKG" IsHidden="true" />
+            <Link Id="HGlMdgCsoG2PpUOKC2C8VA" Ids="GcUuVnKqTiWMr16N6YNCZZ,P33MTf6WnozOM7eGhYzilR" IsHidden="true" />
+            <Link Id="So6KnJ30emxMecdcydTzH5" Ids="Cd6rUUbI8krNp4BatW8pcH,KnJ7LEIBAhZNYQIrH10z9G" IsHidden="true" />
+            <Link Id="GSYhtZHxEwPMcdQUF67dk3" Ids="P33MTf6WnozOM7eGhYzilR,Jn4MQIq2375PYWwPp3dQCK" />
+            <Link Id="Ry5YW8vdZghNsAUjFh2hAQ" Ids="KnJ7LEIBAhZNYQIrH10z9G,Lebv8mH06wrLu5c14Xg9E8" />
+            <Link Id="OkRdYOAhN7TOIQCtO8KxE2" Ids="FydGgPzgtFQMI8PHwIModE,UqLSa6HalcQL1GQmP9UoAo" />
+            <Link Id="JpsJvkVF5apNHa8XtbPHXB" Ids="ELmLkHRLBD2PdkDWkgt8PD,DNSzEhF4osKLfQWAcHXRsp" IsHidden="true" />
+            <Link Id="ENlc8aORWgXOhrS1EXFPM3" Ids="K9myjgkNuMINrrZf5U7PWd,KHWIEvYfRBfQCDhdvjZsy1,BWHwNwXZv8XLuou0kSbaNq" />
+            <Link Id="LYuWPdsTAxdLWyhnnJgzDN" Ids="GWfO7Gwma58MbJ7GvPQlMw,ELmLkHRLBD2PdkDWkgt8PD" />
+            <Link Id="IIjjroxkOcdLnzsft5fSjt" Ids="AeiWyUQBxrhMEeWH0OiD3Z,VcGjpTTBObDOKYcGzyybau" />
+            <Link Id="LeUTEwp6YjtLLKD92d91no" Ids="C1dvIEE1BPNLNdYb9LLfXV,C46kWyP2J4ZPjmm981rMAj" />
+            <Link Id="BvKyQbbxqgbPN39nlnrNLb" Ids="DDq9NtmWIibMZimyUepMV5,UHghVFLFfyCLGyz7aWCD1O" />
+            <Link Id="RF8tsw8ySmfLAMbmTsiCUo" Ids="VYRAoytJKcLL0HJXs4Qiza,MIXSTF2wBmTLXbIKJ05UbT" />
+            <Link Id="LIpgjtjW9wZPdUo77a8Ynd" Ids="EyJOvglCgX4MLBxyCiudK5,MxnYiw6f9JDLwlj10swonE" />
+            <Link Id="K0AMGsNDHm8LdhrcO4jn65" Ids="N4ba85Pr9LyOBHampi4L7u,MnIrnhAhFEhLfmc9iOtcyz" />
+            <Link Id="REIcZSuHSebMFCTIf1uFm3" Ids="IvG0KdoQ9rGMCfgUN0lZZp,JgC6MYbxlS1QDdHNbi7qnI" />
+            <Link Id="Rd9hbd9HvNtQBNFIgyt0sQ" Ids="K76lTijzjZZQRXcbGnQyMk,LjRcLyRYjQTL6r2G72U1Dx" />
+            <Link Id="Oz2YwVmvkzUNY3MjFfw242" Ids="KgclaBeMwdbPWj3NF7TSN5,ML895Ub6iwHMn6bY2qWHrC" />
+            <Link Id="V6YUEjFYKo7NFvq0V3l7pK" Ids="QnqWTcFPzeaOlIWK6DFZNV,I1KCXRFlc56LhwEiPPZp2E" IsHidden="true" />
+            <Link Id="TQrGvM8OtEQOsLX6m9SIfQ" Ids="MbevPEfTVHiQEJmaQRQzTc,F8JhmocSEZBQPpciz0Gnvp" />
+            <Link Id="CGbS0avndBbLPYXWpHEF20" Ids="TylSnZ7ElCDNiTNQROZc85,IJkUUH6AV6oNyYyM3wfyLG" />
+            <Link Id="Ds2mkLdB75lMDTFIyUfqm0" Ids="UdxrbsIVK34O08hANLhXh7,VHFY2zPYpWCNheQDczgdTm" />
+            <Link Id="GmwFkevZXUmLesj6C7u7EK" Ids="CNnpVviRFLVPLLghhCEE7I,MSgrm4PPCcGPrkethMgFSR" />
+            <Link Id="PmShnVcdAHYNfkAPOpuuDb" Ids="KoGLpmJGmNuMBVCYJqJuOj,QsDNnDvS7AVQZBcL37Pe5y" />
+            <Link Id="QP9gl4Aa4YsOFCl520WFzE" Ids="QsDNnDvS7AVQZBcL37Pe5y,BjiBk8NXp8HL2hj8ydkah3" />
+            <Link Id="KT9kc3I6Y2JNny8N7zfXOE" Ids="QsDNnDvS7AVQZBcL37Pe5y,HkwusbOBxEPPHsUPLlB6W4" />
+            <Link Id="HftbbrL1E7HNwCKph6kxy1" Ids="TUahzGGrtU2MVOcrUXDgvJ,VbZkiWB0WXvQDRKRAx2DcX" />
+            <Link Id="KiHT7tSyrm3NEXtBnYS3gi" Ids="OUBgRBGTroCP2CqMmjxpq1,TUahzGGrtU2MVOcrUXDgvJ" IsHidden="true" />
+            <Link Id="RcLu9GVIMGPNd1kvxiTKtb" Ids="NKbckpPLKfhONKlyJh6FV1,VZqR9o8TNZgPCS6vWCNmVt" />
+            <Link Id="ROtefQBDUh8NSNuU5X7MlC" Ids="OB1VEuJaHTRQR5UWJd9DKc,NKbckpPLKfhONKlyJh6FV1" IsHidden="true" />
+            <Link Id="TCMKqxBQKE9NWxck9rqL1P" Ids="I1KCXRFlc56LhwEiPPZp2E,IeIhDGc3Q7zQFT4up5opPS" />
+            <Link Id="BmEv7JsnPzEMl7EFnblFOp" Ids="Hm26lRA6GDkPzesjqTsn95,Qyj9y0GuanDMZvhmuxv0qE" />
+            <Link Id="VtAHkfFkFBlLIPybaePTlD" Ids="UuLDUc3sIMoLbVe9BfV48G,Hm26lRA6GDkPzesjqTsn95" IsHidden="true" />
+            <Link Id="D1x4G40Y4SGO3m7Rbhjv6C" Ids="JmyUN95v58lQDkwdKK7ZxQ,NEO6q6I2i4dPjNnJzhLmGp" />
+            <Link Id="HWdOVVwN8ZWP6DqIBHj1OV" Ids="A4HO3ad8iuwOGSNse4CpzN,VvuHJ5p18gULslOclbpmIx" />
+            <Link Id="AyL6FEN09egLiYbnZmTZmH" Ids="KyVTw1RqX3ALxmTZosnBz0,QlK5slwNHftPF4bdWHCAQV" />
+            <Link Id="QmndetAKJ19MRdkrcj6K9h" Ids="Mhiump7lQ2KMyc8fto6ghL,EdNY9C5tIlFN2EvkvaKpM1" />
+            <Link Id="SEyMCNKYWI5MlIZcuZIWhh" Ids="SMq7r9CyGtXLfPKVO9mvcs,Mhiump7lQ2KMyc8fto6ghL" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ ShadowCatcherDataRetrieverRenderer ************************
+
+-->
+        <Node Name="ShadowCatcherDataRetrieverRenderer" Bounds="518,749" Id="KRKJA7TMNEpL7U1Dv4xB32">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ClassDefinition" Name="Class" />
+          </p:NodeReference>
+          <p:Interfaces>
+            <TypeReference LastCategoryFullName="Stride.API.Rendering" LastDependency="VL.Stride.vl">
+              <Choice Kind="MutableInterfaceType" Name="IRenderer" />
+            </TypeReference>
+          </p:Interfaces>
+          <Patch Id="UnCOxsvliVaPrGoE68On4m">
+            <Canvas Id="L04ZWGHfmQaMGNmzB9nXat" CanvasType="Group">
+              <ControlPoint Id="C8x51fcLrN1OS8lL4g9LJ5" Bounds="822,743" />
+              <Node Bounds="1361,1099,51,26" Id="MQdGP5bxJN2Njr0LO7pv0O">
+                <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
+                  <Choice Kind="OperationCallFlag" Name="Draw" />
+                </p:NodeReference>
+                <Pin Id="NpZSrwEZN5GOvO5HU8assO" Name="Input" Kind="StateInputPin" />
+                <Pin Id="DAT8KgXFqP5LykZU3v5buT" Name="Context" Kind="InputPin" />
+                <Pin Id="IQFWcGSbr2DLZsm8vfgya4" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="1364,909" />
+              <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="1363,853" />
+              <Node Bounds="884,1191,366,114" Id="E2oflgh7P6CM3IqV2TYFc9">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="KxBUKEtfv0fOxAQDvjnjxZ" Name="Condition" Kind="InputPin" />
+                <Patch Id="NVm0f2JOHhOMbyHJUlAFrx" ManuallySortedPins="true">
+                  <Patch Id="BqhqQQMgSiBQAz4lJmAZud" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="L1y86PLt1KkMUcqinp6zKl" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="896,1259,81,26" Id="AcWwmmky3c7MBjc6PXWyWd">
+                    <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="Stride" />
+                      <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
+                      <Choice Kind="OperationCallFlag" Name="Set" />
+                    </p:NodeReference>
+                    <Pin Id="EPlb5vrWJZ8P5VtmajBQ27" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FZp5qnymERONLavHVZuT7J" Name="Property Key" Kind="InputPin" />
+                    <Pin Id="RATmuWYtZAEMPrtiEcPF30" Name="Tag Value" Kind="InputPin" />
+                    <Pin Id="QnYylTDVqZvL20CCf6OwqT" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="1121,1214,117,19" Id="G6uykTFllYeNhgISZJviWo">
+                    <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessAppFlag" Name="GetShadowParameters" />
+                    </p:NodeReference>
+                    <Pin Id="Ncu9UhXBddDQJbNOYVnmcN" Name="Input" Kind="InputPin" />
+                    <Pin Id="K3fuXPky3owOXIsRIqyPol" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+              </Node>
+              <Node Bounds="823,899,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
+                <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Tags" />
+                </p:NodeReference>
+                <Pin Id="Q1oJb8MLljLOQ6mgA1aVGD" Name="Input" Kind="StateInputPin" />
+                <Pin Id="DMbYsqvPc4SPThtdslUlUE" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="EDRuTOkzYh6PRNnmbXMt0l" Name="Tags" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="895,982,81,26" Id="ITJnvf0PA2MOU3PyFQtZqJ">
+                <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll" OverloadStrategy="AllPinsThatAreNotCommon">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
+                  <Choice Kind="OperationCallFlag" Name="TryGetValue" />
+                  <PinReference Kind="InputPin" Name="Property Key">
+                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Core" LastDependency="Stride.Core.dll">
+                      <Choice Kind="TypeFlag" Name="PropertyKey`1" />
+                      <p:TypeArguments>
+                        <TypeParameterReference />
+                      </p:TypeArguments>
+                    </p:DataTypeReference>
+                  </PinReference>
+                  <PinReference Kind="OutputPin" Name="Value" ParameterModifier="ref">
+                    <p:DataTypeReference p:Type="TypeParameterReference" />
+                  </PinReference>
+                </p:NodeReference>
+                <Pin Id="UeAxhYBk6PJNIKrLmNoWkc" Name="Input" Kind="StateInputPin" />
+                <Pin Id="I7addska4f1OEFHYa3Gapr" Name="Property Key" Kind="InputPin" />
+                <Pin Id="J99x0MKAcmEPQEHl84ofJQ" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="C1JV9EANnLvLpeklUutEFA" Name="Result" Kind="OutputPin" />
+                <Pin Id="AKyDxhhOVjzMMKRZv0Shny" Name="Value" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="932,1037,37,19" Id="J7snb5PbMDnLSr0Yv8FN3G">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="NOT" />
+                </p:NodeReference>
+                <Pin Id="EtYP5E8bjrwPgefOxIONir" Name="Input" Kind="StateInputPin" />
+                <Pin Id="EWoOSpfJn8WLVInjrwqZe7" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Pad Id="S78rsCgoGA1LtdGfKVYSJJ" SlotId="TCuBmbFlbQ6PEmI1LLzLY6" Bounds="1602,898" />
+              <ControlPoint Id="PERgaE6IPCxNcvWx4SVk8R" Bounds="1602,849" />
+              <Node Bounds="1058,947,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
+                <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="ShadowCatcherDataKey" />
+                </p:NodeReference>
+                <Pin Id="FqV2QIIT2vsLlmwb3dzckZ" Name="Singleton" Kind="OutputPin" />
+              </Node>
+            </Canvas>
+            <Patch Id="PYcVQQWp6PkPYTo8m9u9KV" Name="Create" />
+            <ProcessDefinition Id="BsrycrTeJZ2QSp24BsEq5E" HasStateOut="true">
+              <Fragment Id="EMshQ1QdD2uL1U2wp2SAAN" Patch="PYcVQQWp6PkPYTo8m9u9KV" Enabled="true" />
+              <Fragment Id="Q4I6up1cThnMezlHoJXPCp" Patch="A7yxmq7xlgROzf9OCaTbx6" />
+              <Fragment Id="HEADEpqPcFeMfKsd7XOLwo" Patch="NVWQ07a49cROHCLR8dmmz5" Enabled="true" />
+              <Fragment Id="AkiLcxNEFAgOO7OCAnuqRV" Patch="OEB3dBZF9mXL28hxAJgn0c" Enabled="true" />
+            </ProcessDefinition>
+            <Patch Id="A7yxmq7xlgROzf9OCaTbx6" Name="Draw">
+              <Pin Id="ThISyoqzkA2LqxFH7SJgKD" MergeId="45458" Name="Context" Kind="InputPin" />
+            </Patch>
+            <Link Id="JXkqF1OyyKjLYP7pgBxN7v" Ids="ThISyoqzkA2LqxFH7SJgKD,C8x51fcLrN1OS8lL4g9LJ5" IsHidden="true" />
+            <Patch Id="NVWQ07a49cROHCLR8dmmz5" Name="Update" ManuallySortedPins="true">
+              <Pin Id="NLHRb9iLlutO0V1rXdc3B2" Name="Input" Kind="InputPin" />
+            </Patch>
+            <Link Id="RPzj1m85K2TP43MJtR82sH" Ids="C8x51fcLrN1OS8lL4g9LJ5,DAT8KgXFqP5LykZU3v5buT" />
+            <Link Id="NFhe6ZUSJdTNyyKRv2F7kC" Ids="Nx6K7kWkA87OtTB6bRmS1k,NpZSrwEZN5GOvO5HU8assO" />
+            <Link Id="Uuf8eHCyasKPwn1A5U0BYP" Ids="K5oNmlJ0fOSMp4V5bX6uiJ,Nx6K7kWkA87OtTB6bRmS1k" />
+            <Link Id="TkPJQgtcADdOVh3NJPU8Wq" Ids="NLHRb9iLlutO0V1rXdc3B2,K5oNmlJ0fOSMp4V5bX6uiJ" IsHidden="true" />
+            <Link Id="OyMlH18CTwQO16tWsJV4XN" Ids="C8x51fcLrN1OS8lL4g9LJ5,Q1oJb8MLljLOQ6mgA1aVGD" />
+            <Link Id="ULMxDEjPceePrWUJoRNI4D" Ids="EDRuTOkzYh6PRNnmbXMt0l,UeAxhYBk6PJNIKrLmNoWkc" />
+            <Link Id="NeaSsohgW9SNrEdbohxFxA" Ids="C1JV9EANnLvLpeklUutEFA,EtYP5E8bjrwPgefOxIONir" />
+            <Link Id="QKkzYibhMROPqPFsq11QIo" Ids="EWoOSpfJn8WLVInjrwqZe7,KxBUKEtfv0fOxAQDvjnjxZ" />
+            <Link Id="GZkDcpv7y99OTTljpHW2xi" Ids="J99x0MKAcmEPQEHl84ofJQ,EPlb5vrWJZ8P5VtmajBQ27" />
+            <Link Id="GTNwYnNdrSyPbIkAhThTS4" Ids="K3fuXPky3owOXIsRIqyPol,RATmuWYtZAEMPrtiEcPF30" />
+            <Slot Id="TCuBmbFlbQ6PEmI1LLzLY6" Name="Compositor" />
+            <Link Id="L9EtnIbTKkXMbnQcPmWhx4" Ids="S78rsCgoGA1LtdGfKVYSJJ,Ncu9UhXBddDQJbNOYVnmcN" />
+            <Link Id="BouM5LQTWXTL7SBMFOSDSC" Ids="PERgaE6IPCxNcvWx4SVk8R,S78rsCgoGA1LtdGfKVYSJJ" />
+            <Link Id="TdiD8Ae7yxXNcwDdoW9KX1" Ids="Qy3ohbILJQ8M3zGxlXFWIO,PERgaE6IPCxNcvWx4SVk8R" IsHidden="true" />
+            <Link Id="PqRFATsehsnLps6mqtpBiW" Ids="FqV2QIIT2vsLlmwb3dzckZ,I7addska4f1OEFHYa3Gapr" />
+            <Link Id="MqHLTM6d7xEMkYluZgq8gy" Ids="FqV2QIIT2vsLlmwb3dzckZ,FZp5qnymERONLavHVZuT7J" />
+            <Patch Id="OEB3dBZF9mXL28hxAJgn0c" Name="SetCompositor">
+              <Pin Id="Qy3ohbILJQ8M3zGxlXFWIO" Name="Compositor" Kind="InputPin" />
+            </Patch>
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ ShadowCatcherDataKey ************************
+
+-->
+        <Node Name="ShadowCatcherDataKey" Bounds="1009,449,281,211" Id="NI2usixxVXaLQGQ59UGE1z">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="OperationDefinition" Name="Operation" />
+          </p:NodeReference>
+          <Patch Id="AjQ7cRqNCwNMnPmhAc8q1R">
+            <Node Bounds="1090,469,188,129" Id="IYoj0iIy2VoPTEVdfu3xR7">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="OperationCallFlag" Name="SingleInstance" />
+              </p:NodeReference>
+              <Pin Id="F5Naw5RY6NMPuwb3WCW6Yb" Name="Force New Instance" Kind="InputPin" />
+              <Pin Id="BuBoXdCeSG1PM8QZdbDRWV" Name="On Stop" Kind="InputPin" />
+              <Pin Id="RjyLbVtklzOLBLb1xsgeyP" Name="Singleton" Kind="OutputPin" />
+              <Patch Id="LAdt2gNSIYeL5AINZnPpLb" Name="Producer" ManuallySortedPins="true">
+                <Pin Id="AKixyhlpvfkNlWjgFf3S6N" Name="Result" Kind="OutputPin" />
+                <ControlPoint Id="D7VXX4CEhKeLYU4GrkPfSK" Bounds="1106,591" />
+                <Node Bounds="1103,533,68,26" Id="BxItyliUiQCQV1G6EKzCE7">
+                  <p:NodeReference LastCategoryFullName="Stride.Core.PropertyKey`1" LastDependency="Stride.Core.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="PropertyKey`1" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="EZ23lnVwQFnPNNcKGFdke3" Name="Name" Kind="InputPin" />
+                  <Pin Id="GaCJG6S4VPtLN9sUjtLCNl" Name="Owner Type" Kind="InputPin" />
+                  <Pin Id="E3lB4PIFYURPau9Fpm82Sa" Name="Metadatas" Kind="InputPin" />
+                  <Pin Id="BFSPovEUcCYPnLT9wAmgbS" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="Q6v2cnWsi0NLsnUzeDoP4j" Comment="Name" Bounds="1106,497,112,15" ShowValueBox="true" isIOBox="true" Value="ShadowCatcherData">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+              </Patch>
+            </Node>
+            <Link Id="ILQC2bEJFZULEywwYn2C3W" Ids="D7VXX4CEhKeLYU4GrkPfSK,AKixyhlpvfkNlWjgFf3S6N" IsHidden="true" />
+            <ControlPoint Id="NuC8XKO5cVwQB9oWu0ko5S" Bounds="1092,643" />
+            <Link Id="MLqN2hRVsBYN7noVvCt79s" Ids="RjyLbVtklzOLBLb1xsgeyP,NuC8XKO5cVwQB9oWu0ko5S" />
+            <Link Id="FO3XUa2x96uLTjq5RSxv5k" Ids="NuC8XKO5cVwQB9oWu0ko5S,Nk71fm9yjMWN89P1lhVepj" IsHidden="true" />
+            <Link Id="NpGzsnwqvNXLSDBeAypEwu" Ids="BFSPovEUcCYPnLT9wAmgbS,D7VXX4CEhKeLYU4GrkPfSK" />
+            <Link Id="HrSqfVNwI8vLw19ZzOAP8J" Ids="Q6v2cnWsi0NLsnUzeDoP4j,EZ23lnVwQFnPNNcKGFdke3" />
+            <Pin Id="Nk71fm9yjMWN89P1lhVepj" Name="Singleton" Kind="OutputPin" Bounds="1033,654">
+              <p:TypeAnnotation LastCategoryFullName="Stride.Core" LastDependency="Stride.Core.dll">
+                <Choice Kind="TypeFlag" Name="PropertyKey`1" />
+                <p:TypeArguments>
+                  <TypeReference>
+                    <Choice Kind="TypeFlag" Name="ShadowCatcherData" />
+                  </TypeReference>
+                </p:TypeArguments>
+              </p:TypeAnnotation>
+            </Pin>
+          </Patch>
+        </Node>
       </Canvas>
     </Canvas>
     <!--
@@ -2531,7 +3007,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="GOJilsPYjshQcKnEHDpYlN" Location="VL.Stride" Version="2023.5.2" />
+  <NugetDependency Id="GOJilsPYjshQcKnEHDpYlN" Location="VL.Stride" Version="2023.5.0" />
   <PlatformDependency Id="B9QxKRqJYwTNW107F3zyzE" Location="Stride.Engine.dll" />
   <PlatformDependency Id="Lw3p7rP4oXGLAaZAfvAlUI" Location="Stride.Rendering.dll" />
   <NugetDependency Id="TUXfXeIzYfFLAjZcHPYqnS" Location="System.Reflection" Version="4.3.0" />

--- a/VL.ShadowCatcher.vl
+++ b/VL.ShadowCatcher.vl
@@ -14,7 +14,7 @@
         </p:NodeReference>
         <Patch Id="NhQUm5U58nLLIfFbdpubeS">
           <Canvas Id="TGNklbSH9OhM4EJKQNyrwO" CanvasType="Group">
-            <Node Bounds="754,1098,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
+            <Node Bounds="597,638,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
               <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
@@ -30,18 +30,18 @@
               <Pin Id="ChfH4QpRGwHLciNOwh20Oy" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="PsNo2ehteioPThgMNATyIa" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="819,849" />
-            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="981,842" />
-            <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="585,1236" />
-            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="777,716" />
-            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="937,1078" />
-            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="859,741" />
-            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="852,1037" />
-            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="899,1057" />
-            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="1156,847" />
-            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="1177,876" />
-            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="899,773" />
-            <Node Bounds="583,1173,85,19" Id="Iv8QmhFRdfxO0nnglV0UEB">
+            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="662,389" />
+            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="824,382" />
+            <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="428,776" />
+            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="620,256" />
+            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="780,618" />
+            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="702,281" />
+            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="695,577" />
+            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="742,597" />
+            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="999,387" />
+            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="1020,416" />
+            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="742,313" />
+            <Node Bounds="426,713,85,19" Id="Iv8QmhFRdfxO0nnglV0UEB">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -54,7 +54,7 @@
               <Pin Id="M7T7sE2CDYXOLak10XMXbx" Name="Enabled" Kind="InputPin" />
               <Pin Id="SgsBvnIOFTsMKZaLXrSStk" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="492,1071,145,19" Id="BIHgjdHPLc3MsJimb1Fg0o">
+            <Node Bounds="335,611,145,19" Id="BIHgjdHPLc3MsJimb1Fg0o">
               <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="MeshEntity" />
@@ -69,7 +69,7 @@
               <Pin Id="Hu9osZSpWViLHGBorjqppa" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="VkXlqC4dIcDMGE8ZPvANY1" Name="Entity" Kind="OutputPin" />
             </Node>
-            <Node Bounds="532,1030,77,19" Id="NAr4XndDvUbQawXJFO7aXj">
+            <Node Bounds="375,570,77,19" Id="NAr4XndDvUbQawXJFO7aXj">
               <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ColorMaterial" />
@@ -79,7 +79,7 @@
               <Pin Id="CUAksSoURmoNEvLtxSOCuh" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="H32bPBTM1KfMeVYKMBofja" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="603,966,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
+            <Node Bounds="446,506,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
               <p:NodeReference LastCategoryFullName="Stride.Materials.MiscAttributes.Transparency" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Transparency" NeedsToBeDirectParent="true" />
@@ -91,17 +91,17 @@
               <Pin Id="Mt9TDjWb1AKO9dCzjiKKEA" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="FwtCYbbNCR2QGPh7hPEGWZ" Name="Output" Kind="OutputPin" />
             </Node>
-            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="625,894,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
+            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="468,434,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
               <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector4" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="604,844,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="447,384,35,15" ShowValueBox="true" isIOBox="true" Value="0">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="CMpzKF371B5Pc0s5lxnUKK" Bounds="325,1063,144,58" ShowValueBox="true" isIOBox="true" Value="For updating render view frustum used by Directional light">
+            <Pad Id="CMpzKF371B5Pc0s5lxnUKK" Bounds="168,603,144,58" ShowValueBox="true" isIOBox="true" Value="For updating render view frustum used by Directional light">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
@@ -110,10 +110,10 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="1100,802" />
-            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="1087,764" />
-            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="945,815" />
-            <Node Bounds="774,983,188,19" Id="VvamwIIbEbCL1iB2OsvFHP">
+            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="943,342" />
+            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="930,304" />
+            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="788,355" />
+            <Node Bounds="617,523,188,19" Id="VvamwIIbEbCL1iB2OsvFHP">
               <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ShadowCatcherDataRetrieverRenderer" />
@@ -121,7 +121,7 @@
               <Pin Id="UGLWhvLAFVJPej7ukTOgKR" Name="Input" Kind="InputPin" />
               <Pin Id="CbiESkhbWwXMJsm4gpo4aj" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="774,919,388,19" Id="UR5kT7mqBX9N5uwowJxlBp">
+            <Node Bounds="617,459,388,19" Id="UR5kT7mqBX9N5uwowJxlBp">
               <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ShadowCatcherRenderer" />
@@ -138,8 +138,8 @@
               <Pin Id="Lt63z2kVv7nLEdrnarVzvF" Name="Depth Stencil State" Kind="InputPin" />
               <Pin Id="GbjzedfO4jTOfxZxje0Tyu" Name="Rasterizer State" Kind="InputPin" />
             </Node>
-            <ControlPoint Id="DhzIRqeDHaRMkSCcIvzqZy" Bounds="495,882" />
-            <ControlPoint Id="OkO5TLf1z7MQJq7zLO5eza" Bounds="515,997" />
+            <ControlPoint Id="DhzIRqeDHaRMkSCcIvzqZy" Bounds="338,422" />
+            <ControlPoint Id="OkO5TLf1z7MQJq7zLO5eza" Bounds="358,537" />
           </Canvas>
           <ProcessDefinition Id="OYIyatA91KLOCZaTdgqMhW">
             <Fragment Id="AM3gkuf1OjILQKsjuNe11b" Patch="TZOUr2B4xdnNuWwnWeWSzU" Enabled="true" />
@@ -358,8 +358,8 @@
           </p:Interfaces>
           <Patch Id="QejBHbOpLTJOuzZIrA4NNY">
             <Canvas Id="LLYUbQWfLcmPsoyV9K3uVm" CanvasType="Group">
-              <ControlPoint Id="JmyUN95v58lQDkwdKK7ZxQ" Bounds="2182,728" />
-              <Node Bounds="2779,1903,51,26" Id="DEUUMoIDhvAPsnwDvyKYTm">
+              <ControlPoint Id="JmyUN95v58lQDkwdKK7ZxQ" Bounds="326,93" />
+              <Node Bounds="685,1200,51,26" Id="DEUUMoIDhvAPsnwDvyKYTm">
                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
@@ -369,7 +369,7 @@
                 <Pin Id="NEO6q6I2i4dPjNnJzhLmGp" Name="Context" Kind="InputPin" />
                 <Pin Id="Tl7wyt0Ir8sN0xW7rB3ris" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="2716,1557,525,19" Id="EFcDZ0rAt8dPKWpoTPVFd8">
+              <Node Bounds="622,911,525,19" Id="EFcDZ0rAt8dPKWpoTPVFd8">
                 <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
@@ -402,7 +402,7 @@
                 <Pin Id="AjPi6TruA1UNq43LvfmH86" Name="Parameter Setter" Kind="InputPin" />
                 <Pin Id="T2GnL1RO1RbMbGev2XXN4c" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2780,1718,165,19" Id="MPbnltAUkA7MPFGGEws3ik">
+              <Node Bounds="686,1072,165,19" Id="MPbnltAUkA7MPFGGEws3ik">
                 <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
@@ -418,7 +418,7 @@
                 <Pin Id="SiD2SPlsBXdNJ3kGwQtp6r" Name="Draw Count" Kind="InputPin" />
                 <Pin Id="CT97BEWDhmBPGcVX9NAhPe" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="2799,1615,67,19" Id="Iv8HEMBEvGsNWGUS8jym4D">
+              <Node Bounds="705,969,67,19" Id="Iv8HEMBEvGsNWGUS8jym4D">
                 <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
@@ -426,7 +426,7 @@
                 </p:NodeReference>
                 <Pin Id="BPNLoqDTpPsPxulnDLFLfY" Name="Alpha Blend" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2828,1300,46,19" Id="EybVyj1wtVMPHNl1m880tm">
+              <Node Bounds="734,654,46,19" Id="EybVyj1wtVMPHNl1m880tm">
                 <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -436,7 +436,7 @@
                 <Pin Id="TWHULF1KKMTMY03ZRxLN2w" Name="Y" Kind="InputPin" />
                 <Pin Id="EqoiojoXGwtMqwnWThJ1JN" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="2885,1360,25,19" Id="L2u00IR9HlQOjrnWTYmCAw">
+              <Node Bounds="791,714,25,19" Id="L2u00IR9HlQOjrnWTYmCAw">
                 <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="/" />
@@ -445,7 +445,7 @@
                 <Pin Id="Dd3A51t1YAYNi9sJ1eylgM" Name="Input 2" Kind="InputPin" />
                 <Pin Id="R0NYQHJ7xblOD4BN0a7y5I" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2674,1378,165,19" Id="FS2gUWb7P5iOjdVMRu9xEO">
+              <Node Bounds="580,732,165,19" Id="FS2gUWb7P5iOjdVMRu9xEO">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -462,15 +462,15 @@
                 <Pin Id="P9AqbHgdvXDNbeIfWDcpvw" Name="Result 8" Kind="OutputPin" />
                 <Pin Id="QamoN9H9dfpPUZdep5WoYS" Name="Result 9" Kind="OutputPin" />
               </Node>
-              <Pad Id="BZJwQj3XBxQLXPiaZvCthJ" Comment="Cascade Count" Bounds="3027,1156,35,15" ShowValueBox="true" isIOBox="true" Value="4">
+              <Pad Id="BZJwQj3XBxQLXPiaZvCthJ" Comment="Cascade Count" Bounds="933,510,35,15" ShowValueBox="true" isIOBox="true" Value="4">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
-              <ControlPoint Id="LbsvtNcaHprLWUhzfQ7IlQ" Bounds="2957,1676" />
-              <ControlPoint Id="C2oIF41pTsPPxMvbTp9WMo" Bounds="3207,1440" />
-              <ControlPoint Id="AqthvFRkKa9OjYTX3NJyYF" Bounds="3274,1506" />
-              <Node Bounds="2565,899,414,26" Id="CPU2NT8flMqMxh8e9kipNd">
+              <ControlPoint Id="LbsvtNcaHprLWUhzfQ7IlQ" Bounds="863,1030" />
+              <ControlPoint Id="C2oIF41pTsPPxMvbTp9WMo" Bounds="1113,794" />
+              <ControlPoint Id="AqthvFRkKa9OjYTX3NJyYF" Bounds="1180,860" />
+              <Node Bounds="471,253,414,26" Id="CPU2NT8flMqMxh8e9kipNd">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
@@ -484,7 +484,7 @@
                 <Pin Id="LISx9LVm39jLkRQqQD85Wl" Name="Spot Light Count" Kind="OutputPin" />
                 <Pin Id="IxtKMr32FHmMmxkUZh5Iam" Name="Point Light Count" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2498,1117,80,80" Id="QnUuXtO5fjcNF4sTUKxkpM">
+              <Node Bounds="404,471,80,80" Id="QnUuXtO5fjcNF4sTUKxkpM">
                 <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
                   <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AvoidNull" />
@@ -493,10 +493,10 @@
                 <Pin Id="B7FhjROgOEXQEpXF6pUKo7" Name="Output" Kind="OutputPin" />
                 <Patch Id="GlQYWXWTzEYN2bF40SucyD" Name="Create Default Value" ManuallySortedPins="true">
                   <Pin Id="H6ILxGVKFqBP2UwRS5D9WL" Name="Result" Kind="OutputPin" />
-                  <ControlPoint Id="GG50zhylpZCOkQvEW5IPLV" Bounds="2515,1168" />
+                  <ControlPoint Id="GG50zhylpZCOkQvEW5IPLV" Bounds="421,522" />
                 </Patch>
               </Node>
-              <Node Bounds="2514,1061,106,19" Id="MNPA3DvTbhfO7JYIuwOAFp">
+              <Node Bounds="420,415,106,19" Id="MNPA3DvTbhfO7JYIuwOAFp">
                 <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
@@ -507,7 +507,7 @@
                 <Pin Id="VCVW5DD47hQNld7JXsn36b" Name="Output" Kind="OutputPin" />
                 <Pin Id="Fl82CqOwHSsL3K6C86eA7m" Name="Has Changed" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2498,1220,44,26" Id="HmXto4qRcVxO0VAGbjWneN">
+              <Node Bounds="404,574,44,26" Id="HmXto4qRcVxO0VAGbjWneN">
                 <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Texture" />
@@ -517,16 +517,16 @@
                 <Pin Id="KT0aL8uuTyxLx16L0XBKtl" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="VZucdFP1QAbMHvZpPnxlOH" Name="Width" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="UU7uf4taU6sONUGywKMNKY" Bounds="2501,1041" />
-              <ControlPoint Id="CvDupSj5rRVN3mJieo7xQB" Bounds="3090,1219" />
-              <Pad Id="NSxVHoSsU1cLhyjMLzzzmj" Comment="Width" Bounds="2830,1271,35,15" ShowValueBox="true" isIOBox="true" />
-              <ControlPoint Id="QkWLD2hWvG9PIdSYzqiruz" Bounds="2909,1653" />
-              <ControlPoint Id="FX8KPluMrEDPujWYSfvY5I" Bounds="2885,1626" />
-              <ControlPoint Id="EMdQlRZuL5NLn1fsBp07pm" Bounds="3265,1483" />
-              <ControlPoint Id="FsvhIZEQc4lLffGggv20SI" Bounds="3234,1464" />
-              <ControlPoint Id="NjcKqoUjNizOqOYd9gHqN8" Bounds="3327,1208" />
-              <ControlPoint Id="AS21xEOJjDtQSc21RNfl2n" Bounds="3155,1260" />
-              <Node Bounds="3241,1102,113,19" Id="UwdmAgqE8YIOSV9CyVQgTj">
+              <ControlPoint Id="UU7uf4taU6sONUGywKMNKY" Bounds="407,395" />
+              <ControlPoint Id="CvDupSj5rRVN3mJieo7xQB" Bounds="996,573" />
+              <Pad Id="NSxVHoSsU1cLhyjMLzzzmj" Comment="Width" Bounds="736,625,35,15" ShowValueBox="true" isIOBox="true" />
+              <ControlPoint Id="QkWLD2hWvG9PIdSYzqiruz" Bounds="815,1007" />
+              <ControlPoint Id="FX8KPluMrEDPujWYSfvY5I" Bounds="791,980" />
+              <ControlPoint Id="EMdQlRZuL5NLn1fsBp07pm" Bounds="1171,837" />
+              <ControlPoint Id="FsvhIZEQc4lLffGggv20SI" Bounds="1140,818" />
+              <ControlPoint Id="NjcKqoUjNizOqOYd9gHqN8" Bounds="1233,562" />
+              <ControlPoint Id="AS21xEOJjDtQSc21RNfl2n" Bounds="1061,614" />
+              <Node Bounds="1147,456,113,19" Id="UwdmAgqE8YIOSV9CyVQgTj">
                 <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ImmutableTexture2D" />
@@ -539,12 +539,12 @@
                 <Pin Id="U16oIYvMfiEPn0CD6fwzLD" Name="Output" Kind="OutputPin" />
                 <Pin Id="Qont3IhJbPwMPy3ASbN4uP" Name="Has Changed" Kind="OutputPin" />
               </Node>
-              <Pad Id="SYVCXLVGG8pPusTIhdrO6I" Comment="Size" Bounds="3303,1055,35,28" ShowValueBox="true" isIOBox="true" Value="4, 4">
+              <Pad Id="SYVCXLVGG8pPusTIhdrO6I" Comment="Size" Bounds="1209,409,35,28" ShowValueBox="true" isIOBox="true" Value="4, 4">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Int2" />
                 </p:TypeAnnotation>
               </Pad>
-              <Node Bounds="3237,958,65,19" Id="LWu8MESeehcPdXALMxg8XA">
+              <Node Bounds="1143,312,65,19" Id="LWu8MESeehcPdXALMxg8XA">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -556,7 +556,7 @@
                 <Pin Id="Mxnqp2WGi17L07mtPcfaxn" Name="Input 3" Kind="InputPin" />
                 <Pin Id="LkYC8JPAIu5OQcNRYK5Y6h" Name="Input 4" Kind="InputPin" />
               </Node>
-              <Node Bounds="3257,916,22,19" Id="Nqol9R5c2yALLzIvSpBUhT">
+              <Node Bounds="1163,270,22,19" Id="Nqol9R5c2yALLzIvSpBUhT">
                 <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -565,7 +565,7 @@
                 <Pin Id="NPu58he7shuNQ0G8OlNHNn" Name="Input" Kind="StateInputPin" />
                 <Pin Id="IAhRvhBkLMjLkpgP6a346i" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="3238,1000,65,19" Id="BECokndpQFqM0mP9fyKjk3">
+              <Node Bounds="1144,354,65,19" Id="BECokndpQFqM0mP9fyKjk3">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -577,7 +577,7 @@
                 <Pin Id="Fohw5R0wtTfMYxawAJ25OX" Name="Input 3" Kind="InputPin" />
                 <Pin Id="Aq7sgrMGnGDPQopIoo5YTr" Name="Input 4" Kind="InputPin" />
               </Node>
-              <Node Bounds="3238,1041,47,19" Id="PBXXN4746sLLUstVEuZQhJ">
+              <Node Bounds="1144,395,47,19" Id="PBXXN4746sLLUstVEuZQhJ">
                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -586,9 +586,9 @@
                 <Pin Id="V1kmJs7Mx7xOOcoFF6TGsb" Name="Input" Kind="StateInputPin" />
                 <Pin Id="B37zOfDIFlmMbi7iadloL6" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="Mggts27At2QL8b8soR7NpH" Bounds="3256,1131" />
-              <Pad Id="PScnJMt7ajoOod1uWfLR9a" SlotId="OejTYBo1NP6N2rml0woFBV" Bounds="3256,1173" />
-              <Node Bounds="3153,1296,96,110" Id="OLRYM2sslU8OF7ps36EeNM">
+              <ControlPoint Id="Mggts27At2QL8b8soR7NpH" Bounds="1162,485" />
+              <Pad Id="PScnJMt7ajoOod1uWfLR9a" SlotId="OejTYBo1NP6N2rml0woFBV" Bounds="1162,527" />
+              <Node Bounds="1059,650,96,110" Id="OLRYM2sslU8OF7ps36EeNM">
                 <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
                   <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AvoidNull" />
@@ -597,10 +597,10 @@
                 <Pin Id="JWSgNlO37fYMUslHRi5nTM" Name="Output" Kind="OutputPin" />
                 <Patch Id="CWQ4KlVR05FLzC8hjI3cpi" Name="Create Default Value" ManuallySortedPins="true">
                   <Pin Id="CBbpcFrceZYPBFtQJA9exN" Name="Result" Kind="OutputPin" />
-                  <ControlPoint Id="RUzzhF9iOEwLmQMWayU05w" Bounds="3170,1376" />
+                  <ControlPoint Id="RUzzhF9iOEwLmQMWayU05w" Bounds="1076,730" />
                 </Patch>
               </Node>
-              <Node Bounds="3323,1244,96,110" Id="OmseUEuqLdIMUYgwsp6CSh">
+              <Node Bounds="1229,598,96,110" Id="OmseUEuqLdIMUYgwsp6CSh">
                 <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
                   <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AvoidNull" />
@@ -609,17 +609,17 @@
                 <Pin Id="BrjeaDtDHV9P7Ey03uo4hy" Name="Output" Kind="OutputPin" />
                 <Patch Id="U4utc9GxdAbOo72EPKWGWp" Name="Create Default Value" ManuallySortedPins="true">
                   <Pin Id="QqCwdlWWXXHQTTv5xAzYFV" Name="Result" Kind="OutputPin" />
-                  <ControlPoint Id="Q3zw4mlruaFOKTI3Ka8ncY" Bounds="3340,1324" />
+                  <ControlPoint Id="Q3zw4mlruaFOKTI3Ka8ncY" Bounds="1246,678" />
                 </Patch>
               </Node>
-              <Node Bounds="2564,755,123,19" Id="FijZE5S6Ru1QVxx341dNjZ">
+              <Node Bounds="470,109,123,19" Id="FijZE5S6Ru1QVxx341dNjZ">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ShadowCatcherDataKey" />
                 </p:NodeReference>
                 <Pin Id="MipkAqIGonrNvIMgf0iJiu" Name="Singleton" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2488,812,81,26" Id="Gl0bOK3YLwFMYqtruvlxzb">
+              <Node Bounds="394,166,81,26" Id="Gl0bOK3YLwFMYqtruvlxzb">
                 <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
@@ -642,7 +642,7 @@
                 <Pin Id="FAnM4sFo90lPRp8nnfswBW" Name="Result" Kind="OutputPin" />
                 <Pin Id="JZc56BxxbKGOYVU8WV5OYu" Name="Value" Kind="OutputPin" />
               </Node>
-              <Node Bounds="2419,768,74,26" Id="T5O5gk6DfRoQL729Iug6Kg">
+              <Node Bounds="325,122,74,26" Id="T5O5gk6DfRoQL729Iug6Kg">
                 <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
@@ -652,6 +652,7 @@
                 <Pin Id="F3VjN1hR4whP3Bhocp8XAs" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="AJkGDEsMrINMDUNNktOFUT" Name="Tags" Kind="OutputPin" />
               </Node>
+              <ControlPoint Id="NWCSgniopn1MzcU6KzI6Yi" Bounds="735,1165" />
             </Canvas>
             <Patch Id="ErKdFlYsLL3LcRT3hAojhq" Name="Create" ParticipatingElements="I5TXlz8LnciPhtQvsD9Jn7" />
             <ProcessDefinition Id="HEQMCiBtPVQN8E2zjQVxJQ" HasStateOut="true">
@@ -685,7 +686,6 @@
             <Patch Id="FnmgjOKJhWRMpYSMAlFN6q" Name="SetRasterizerState">
               <Pin Id="OB1VEuJaHTRQR5UWJd9DKc" MergeId="1387" Name="Rasterizer State" Kind="InputPin" Visibility="Optional" />
             </Patch>
-            <Link Id="D1x4G40Y4SGO3m7Rbhjv6C" Ids="JmyUN95v58lQDkwdKK7ZxQ,NEO6q6I2i4dPjNnJzhLmGp" />
             <Slot Id="OejTYBo1NP6N2rml0woFBV" Name="Default" />
             <Link Id="CAe434zbBVaMc3lOgMkiDe" Ids="EqoiojoXGwtMqwnWThJ1JN,Dd3A51t1YAYNi9sJ1eylgM" />
             <Link Id="Gbpn46BlnOaNcnX3PFhkVI" Ids="EqoiojoXGwtMqwnWThJ1JN,S0dVjZq3snlPxk4WCyhmzl" />
@@ -757,6 +757,8 @@
             <Link Id="SsSEmS7i3zxMhOkGNfdiNP" Ids="JZc56BxxbKGOYVU8WV5OYu,KoJxHMTLb2rMPviivjrifo" />
             <Link Id="B0xL33M7z2lQZUGs5hvUmL" Ids="JmyUN95v58lQDkwdKK7ZxQ,VCWrqpzf2aTMUP62d7jKIX" />
             <Link Id="MLX5ALuFXhYPWq8nBH9EhI" Ids="AJkGDEsMrINMDUNNktOFUT,BkeAlfR77sbLpd0TvME5yf" />
+            <Link Id="OgCNOzK2hE2NUXmnP3O53y" Ids="H5CWmZ9XDPaLek5JhguQ2f,NWCSgniopn1MzcU6KzI6Yi" IsHidden="true" />
+            <Link Id="A1eD205n7KRO05HneaLxPD" Ids="NWCSgniopn1MzcU6KzI6Yi,NEO6q6I2i4dPjNnJzhLmGp" />
           </Patch>
         </Node>
         <!--
@@ -775,8 +777,8 @@
           </p:Interfaces>
           <Patch Id="UnCOxsvliVaPrGoE68On4m">
             <Canvas Id="L04ZWGHfmQaMGNmzB9nXat" CanvasType="Group">
-              <ControlPoint Id="C8x51fcLrN1OS8lL4g9LJ5" Bounds="1330,522" />
-              <Node Bounds="1410,1649,51,26" Id="MQdGP5bxJN2Njr0LO7pv0O">
+              <ControlPoint Id="C8x51fcLrN1OS8lL4g9LJ5" Bounds="755,83" />
+              <Node Bounds="835,1135,51,26" Id="MQdGP5bxJN2Njr0LO7pv0O">
                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
@@ -787,21 +789,21 @@
                 <Pin Id="IQFWcGSbr2DLZsm8vfgya4" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="Ol8KVnkNK1WNgmwY1YZPWH" Name="Apply" Kind="InputPin" DefaultValue="False" />
               </Node>
-              <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="1412,1573" />
-              <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="1412,1538" />
-              <Node Bounds="920,1266,431,364" Id="E2oflgh7P6CM3IqV2TYFc9">
+              <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="837,1059" />
+              <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="837,1024" />
+              <Node Bounds="345,752,431,364" Id="E2oflgh7P6CM3IqV2TYFc9">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 </p:NodeReference>
                 <Pin Id="KxBUKEtfv0fOxAQDvjnjxZ" Name="Condition" Kind="InputPin" />
-                <ControlPoint Id="TZQ2Hot5LNzPNBSybYBMtt" Bounds="1334,1272" Alignment="Top" />
-                <ControlPoint Id="JvUSaK0Yr5UNeZ5crtundU" Bounds="1332,1624" Alignment="Bottom" />
+                <ControlPoint Id="TZQ2Hot5LNzPNBSybYBMtt" Bounds="759,758" Alignment="Top" />
+                <ControlPoint Id="JvUSaK0Yr5UNeZ5crtundU" Bounds="757,1110" Alignment="Bottom" />
                 <Patch Id="NVm0f2JOHhOMbyHJUlAFrx" ManuallySortedPins="true">
                   <Patch Id="BqhqQQMgSiBQAz4lJmAZud" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="L1y86PLt1KkMUcqinp6zKl" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="952,1511,85,26" Id="AcWwmmky3c7MBjc6PXWyWd">
+                  <Node Bounds="377,997,85,26" Id="AcWwmmky3c7MBjc6PXWyWd">
                     <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Stride" />
@@ -813,7 +815,7 @@
                     <Pin Id="NIljp4eBBPNP2GU9WODEJ1" Name="Tag Value" Kind="InputPin" />
                     <Pin Id="QnYylTDVqZvL20CCf6OwqT" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1032,1409,117,19" Id="G6uykTFllYeNhgISZJviWo">
+                  <Node Bounds="457,895,117,19" Id="G6uykTFllYeNhgISZJviWo">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GetShadowParameters" />
@@ -821,7 +823,7 @@
                     <Pin Id="Ncu9UhXBddDQJbNOYVnmcN" Name="Input" Kind="InputPin" />
                     <Pin Id="K3fuXPky3owOXIsRIqyPol" Name="Output" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="933,1579,74,26" Id="L9WJwzXE2xjLWUS36NEgVe">
+                  <Node Bounds="358,1065,74,26" Id="L9WJwzXE2xjLWUS36NEgVe">
                     <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
@@ -831,7 +833,7 @@
                     <Pin Id="BXzovYZWWJbQX9U0z42z9v" Name="Value" Kind="InputPin" />
                     <Pin Id="IDAPygsxibALZnZ2ygil3Y" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1032,1453,94,26" Id="RAnNXOh8oUbPe3MOQO3c3C">
+                  <Node Bounds="457,939,94,26" Id="RAnNXOh8oUbPe3MOQO3c3C">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SetFrameNumber" />
@@ -840,7 +842,7 @@
                     <Pin Id="M00kkHOXfOeLZnk4sJZKDQ" Name="Frame Number" Kind="InputPin" />
                     <Pin Id="QBMTr7t38mwQb0zIwpiTUc" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1175,1410,72,26" Id="PtLYSVp2bx7MW1EP8PcGup">
+                  <Node Bounds="600,896,72,26" Id="PtLYSVp2bx7MW1EP8PcGup">
                     <p:NodeReference LastCategoryFullName="Stride.API.Games.GameTime" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FrameCount" />
@@ -849,7 +851,7 @@
                     <Pin Id="TXmlJQ0OxQUL7QupHxMoGB" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="Np8GwSBNQ4XNfyzrv4qPzv" Name="Frame Count" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1178,1371,70,26" Id="TAUep27DBp6QUbsmlvfyyB">
+                  <Node Bounds="603,857,70,26" Id="TAUep27DBp6QUbsmlvfyyB">
                     <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderContext" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="RenderContext" />
@@ -859,7 +861,7 @@
                     <Pin Id="CGEXnBUpvSTLS0axG69htX" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="UchoJ0s2gQQMUELnHoG1qT" Name="Time" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="932,1306,88,26" Id="AbEEWBDB5s4L93QKTpBgyD">
+                  <Node Bounds="357,792,88,26" Id="AbEEWBDB5s4L93QKTpBgyD">
                     <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderDrawContext" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="RenderDrawContext" NeedsToBeDirectParent="true" />
@@ -871,7 +873,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="887,675,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
+              <Node Bounds="312,236,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
                 <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
@@ -881,7 +883,7 @@
                 <Pin Id="DMbYsqvPc4SPThtdslUlUE" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="EDRuTOkzYh6PRNnmbXMt0l" Name="Tags" Kind="OutputPin" />
               </Node>
-              <Node Bounds="956,732,174,26" Id="ITJnvf0PA2MOU3PyFQtZqJ">
+              <Node Bounds="381,293,174,26" Id="ITJnvf0PA2MOU3PyFQtZqJ">
                 <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
@@ -904,14 +906,14 @@
                 <Pin Id="C1JV9EANnLvLpeklUutEFA" Name="Result" Kind="OutputPin" />
                 <Pin Id="AKyDxhhOVjzMMKRZv0Shny" Name="Value" Kind="OutputPin" />
               </Node>
-              <Node Bounds="993,675,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
+              <Node Bounds="418,236,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ShadowCatcherDataKey" />
                 </p:NodeReference>
                 <Pin Id="FqV2QIIT2vsLlmwb3dzckZ" Name="Singleton" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1456,1612,65,19" Id="OyTLWhaP0zWPO09w9jlcMh">
+              <Node Bounds="881,1098,65,19" Id="OyTLWhaP0zWPO09w9jlcMh">
                 <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="IsAssigned" />
@@ -920,21 +922,21 @@
                 <Pin Id="DvMM4qFNpUqNRz2r999upe" Name="Result" Kind="OutputPin" />
                 <Pin Id="OByLMaS018zQI5VSwk04uG" Name="Not Assigned" Kind="OutputPin" />
               </Node>
-              <Node Bounds="1066,835,365,218" Id="HY2STWLe5juNTYmvvb86Zh">
+              <Node Bounds="491,396,365,218" Id="HY2STWLe5juNTYmvvb86Zh">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 </p:NodeReference>
                 <Pin Id="FekHGHekK2kPBqxiCawpnl" Name="Condition" Kind="InputPin" />
-                <ControlPoint Id="Ms1o8mpEhAYPHEw1Jb9xsF" Bounds="1333,841" Alignment="Top" />
-                <ControlPoint Id="IxqQrHJ91xJQcaGAqAQAz6" Bounds="1333,1047" Alignment="Bottom" />
-                <ControlPoint Id="RaIamlQu0lVLjqhiC6KrW7" Bounds="1126,1047" Alignment="Bottom" />
-                <ControlPoint Id="IpMSLzGgPVwMZPbBGA5blz" Bounds="1080,841" Alignment="Top" />
+                <ControlPoint Id="Ms1o8mpEhAYPHEw1Jb9xsF" Bounds="758,402" Alignment="Top" />
+                <ControlPoint Id="IxqQrHJ91xJQcaGAqAQAz6" Bounds="758,608" Alignment="Bottom" />
+                <ControlPoint Id="RaIamlQu0lVLjqhiC6KrW7" Bounds="551,608" Alignment="Bottom" />
+                <ControlPoint Id="IpMSLzGgPVwMZPbBGA5blz" Bounds="505,402" Alignment="Top" />
                 <Patch Id="JW5nSNNltKbPmj6VGFtiLm" ManuallySortedPins="true">
                   <Patch Id="OHmUd0hSRDRNpStjU5d3rx" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="LCnz1ntY4nLPdeDSl0GBdQ" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="1236,958,72,26" Id="VyfD21EO3ZmP24VkOOXdxT">
+                  <Node Bounds="661,519,72,26" Id="VyfD21EO3ZmP24VkOOXdxT">
                     <p:NodeReference LastCategoryFullName="Stride.API.Games.GameTime" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="FrameCount" />
@@ -943,7 +945,7 @@
                     <Pin Id="TH4GnIIJRtkMVFrRzLfsMQ" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="Ens0hr7dX2rMlNsAfW0seh" Name="Frame Count" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1233,918,70,26" Id="TS2InUheuNGL84VrWdeHhT">
+                  <Node Bounds="658,479,70,26" Id="TS2InUheuNGL84VrWdeHhT">
                     <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderContext" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="RenderContext" />
@@ -953,7 +955,7 @@
                     <Pin Id="FC1NCXWhAgVLw14z5vwori" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="B6gePimeF7BNwCi2BrFD82" Name="Time" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1331,864,88,26" Id="M67RugZeRzROQMRBB7y5YC">
+                  <Node Bounds="756,425,88,26" Id="M67RugZeRzROQMRBB7y5YC">
                     <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderDrawContext" LastDependency="VL.Stride.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="RenderDrawContext" NeedsToBeDirectParent="true" />
@@ -963,7 +965,7 @@
                     <Pin Id="LhGIJcBZxWiPc1YkWayura" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="LmW8N4SrakgOyck2CgUqsy" Name="Render Context" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1124,883,96,26" Id="CI3Kscbatl3ODY8qT4Yj0C">
+                  <Node Bounds="549,444,96,26" Id="CI3Kscbatl3ODY8qT4Yj0C">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetFrameNumber" />
@@ -972,7 +974,7 @@
                     <Pin Id="PIib2sQLjrkPRLnNgoAdFa" Name="Output" Kind="StateOutputPin" />
                     <Pin Id="RsvPWzAxI17MJMevV3n0PD" Name="Frame Number" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1124,1006,25,19" Id="AnfKhT3dQTMM9lT5Sunjdp">
+                  <Node Bounds="549,567,25,19" Id="AnfKhT3dQTMM9lT5Sunjdp">
                     <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -984,7 +986,7 @@
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="1078,801,37,19" Id="OGL8Ixoj0I6N6RfQ6z73jt">
+              <Node Bounds="503,362,37,19" Id="OGL8Ixoj0I6N6RfQ6z73jt">
                 <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -992,7 +994,7 @@
                 <Pin Id="S8rWG1pCqqQNsVYCIC6B7N" Name="Input" Kind="StateInputPin" />
                 <Pin Id="Umg2Y0jf8fWPOZqbguB6SW" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Pad Id="O6QzbilCiKMM6Tdt3FxdcR" Bounds="1153,743,98,19" ShowValueBox="true" isIOBox="true" Value="Check if exists">
+              <Pad Id="O6QzbilCiKMM6Tdt3FxdcR" Bounds="578,304,98,19" ShowValueBox="true" isIOBox="true" Value="Check if exists">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
@@ -1001,7 +1003,7 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
-              <Pad Id="BXolapEXXe8NCyZ5akQm6k" Bounds="1364,1417,342,22" ShowValueBox="true" isIOBox="true" Value="Retrieve data if it doesnt exist or is from an older frame">
+              <Pad Id="BXolapEXXe8NCyZ5akQm6k" Bounds="789,903,342,22" ShowValueBox="true" isIOBox="true" Value="Retrieve data if it doesnt exist or is from an older frame">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
@@ -1010,7 +1012,7 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
-              <Pad Id="Ke9bfqimfL1LI54rRrxRTM" Bounds="1447,937,200,19" ShowValueBox="true" isIOBox="true" Value="Check if it is from current frame">
+              <Pad Id="Ke9bfqimfL1LI54rRrxRTM" Bounds="864,487,278,75" ShowValueBox="true" isIOBox="true" Value="Check if it is from current frame to avoid getting it multiple times when there are multiple ShadowCatcher nodes.">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
@@ -1019,7 +1021,7 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
-              <Pad Id="IhCBnUm6ZXEO1y49E717pb" Bounds="1553,1618,213,19" ShowValueBox="true" isIOBox="true" Value="Draw input with updated context">
+              <Pad Id="IhCBnUm6ZXEO1y49E717pb" Bounds="978,1104,213,19" ShowValueBox="true" isIOBox="true" Value="Draw input with updated context">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
@@ -1028,7 +1030,7 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
-              <ControlPoint Id="PNKzeQzu1fvLkd6tTKFAWN" Bounds="924,1152" />
+              <ControlPoint Id="PNKzeQzu1fvLkd6tTKFAWN" Bounds="347,711" />
             </Canvas>
             <Patch Id="PYcVQQWp6PkPYTo8m9u9KV" Name="Create" />
             <ProcessDefinition Id="BsrycrTeJZ2QSp24BsEq5E" HasStateOut="true">

--- a/VL.ShadowCatcher.vl
+++ b/VL.ShadowCatcher.vl
@@ -5,1904 +5,16 @@
     <Canvas Id="EOi0XkRdXSvL66Ap5PM9WU" DefaultCategory="ShadowCatcher" CanvasType="FullCategory">
       <!--
 
-    ************************ SceneWindow ************************
-
--->
-      <Node Name="SceneWindow" Bounds="557,358" Id="OlpO5T6Xl9mMrxfzKPL9UV" Summary="A window to render scenes." Remarks="Requires a RootScene node connected to its input!" Tags="renderer">
-        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
-          <Choice Kind="ContainerDefinition" Name="Process" />
-        </p:NodeReference>
-        <Patch Id="HhbnMDBRPzRPlRU1DPApIv">
-          <Canvas Id="AMpcM2009avNDifQYXUn6x" CanvasType="Group">
-            <ControlPoint Id="Vr3Eepuc1x9L068NnRCIJ3" Bounds="817,703" />
-            <ControlPoint Id="BiDA88lCL7TLSCnioFjAk6" Bounds="194,828,312,0" />
-            <Node Bounds="192,766,577,19" Id="LdVi8Bn3B0QO1uqebkdvA1">
-              <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
-              </p:NodeReference>
-              <Pin Id="AFtzLwpF5TnMoWuRI4XPkR" Name="Bounds" Kind="InputPin" />
-              <Pin Id="IegoiSJZRtWNpUlpNhaLhx" Name="Bound to Document" Kind="InputPin" />
-              <Pin Id="FX2QvItsl7zL8V7nCUdNLl" Name="Dialog If Document Changed" Kind="InputPin" />
-              <Pin Id="DNYs897NyYPP8Cxk9DXZ7h" Name="Save Bounds" Kind="InputPin" />
-              <Pin Id="VqEWI6xmQecNe42aq7rQcr" Name="Back Buffer Format" Kind="InputPin" />
-              <Pin Id="LMu34VpPUUrQWQfw3Yasii" Name="Depth Buffer Format" Kind="InputPin" />
-              <Pin Id="SBsCC3QuWLROxz1ILhPrhr" Name="Multisample Count" Kind="InputPin" />
-              <Pin Id="MVWvk7wPPu5NN5BVK3Emo3" Name="Input" Kind="InputPin" />
-              <Pin Id="JIUOl3kjuYxPl1I9xVWAuy" Name="Render View" Kind="InputPin" />
-              <Pin Id="IaqIPclqpmpOhFTumfLMv9" Name="Title" Kind="InputPin" />
-              <Pin Id="CNTkhrUKUyJMI8Z03VWp2d" Name="Clear Flags" Kind="InputPin" DefaultValue="ColorAndDepth" />
-              <Pin Id="E0y8SHZXD0kMjJXeYwoxMc" Name="Clear Color" Kind="InputPin" DefaultValue="0, 0, 0, 1" />
-              <Pin Id="LFTvE1rHYCbNZRAE1zlbFo" Name="Clear Depth" Kind="InputPin" />
-              <Pin Id="SMfJ17qyBT5NOTr3UD18If" Name="Clear Stencil" Kind="InputPin" />
-              <Pin Id="QCOxqf5CplILE3LisQbhaQ" Name="Clear" Kind="InputPin" DefaultValue="False">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Boolean" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="BN1zEn2leYrOLrWP2XZt0m" Name="Edit Mode" Kind="InputPin" />
-              <Pin Id="SCZ78TQF4J7OLHxtg736eh" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
-              <Pin Id="N5ExraUJAy7P9ZvokNTGl1" Name="Enabled" Kind="InputPin" />
-              <Pin Id="I4WO1WdOMZtNwgvjTeb8nd" Name="Present Interval" Kind="InputPin" />
-              <Pin Id="J2tLUPKnRxWN2NlmOFaDTW" Name="Output" Kind="OutputPin" />
-              <Pin Id="AdB4KTsj7fMLFc4Glpa44o" Name="Client Bounds" Kind="OutputPin" />
-              <Pin Id="DzBERsNeUqyNk5164IYFi3" Name="Input Source" Kind="OutputPin" />
-              <Pin Id="PO7Ph4Ne6HIOUpDVJXB3t3" Name="Back Buffer" Kind="OutputPin" />
-              <Pin Id="AguO2FeDipvPshhFwksta2" Name="Depth Buffer" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="HlhjITIPQDtMBxf78y6kOQ" Bounds="499,732" />
-            <ControlPoint Id="VcC0zidz0HOQAmetm1laM3" Bounds="197,584" />
-            <ControlPoint Id="FIkOY40RnYpQKAItzwVPbN" Bounds="229,614" />
-            <ControlPoint Id="QgqDLhvyoErOBw46BYOOrx" Bounds="262,641" />
-            <ControlPoint Id="Q5CrDi5eRSAPnDtPUZ4QlO" Bounds="297,672" />
-            <ControlPoint Id="DbmYd1et8mGPy5DfvTOFTa" Bounds="705,663" />
-            <Pad Id="HpnQa0IesMdP6cOsdRCGSC" Bounds="658,692,119,25" ShowValueBox="true" isIOBox="true" Value="Clear and RenderView setup are done via Compositor">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">5</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-            <ControlPoint Id="LpFlwCmClEoL8QhFb3KLzl" Bounds="482,126" />
-            <ControlPoint Id="PS1NGKmNL3VMd5ZwWXdFWY" Bounds="565,207" />
-            <ControlPoint Id="MBaCWjmoenjOPkpbwEe7gu" Bounds="519,155" />
-            <ControlPoint Id="LMK1e7xaz8PQOlZINwG5Dn" Bounds="541,182" />
-            <ControlPoint Id="NMcfxAiJNaqNi23dqWX7hz" Bounds="362,732" />
-            <ControlPoint Id="DtW73QY6QtsMY3cks71a44" Bounds="329,701" />
-            <ControlPoint Id="B8Iki5MNfdGM9IenjEN3kU" Bounds="845,737" />
-            <ControlPoint Id="Czm9n0kxdy9MTa1b9ELkHA" Bounds="604,268" />
-            <Node Bounds="219,330,349,88" Id="P7KP3Ag97c2P9q84a0SWL5">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:NodeReference>
-              <Pin Id="BrQYfjfXeyiP5gtHBURsaI" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="F6W14iUChFdO4GnyR67zOE" Bounds="268,336" Alignment="Top" />
-              <ControlPoint Id="UMsdDKGcoZZQLA7CPhBPNL" Bounds="233,412" Alignment="Bottom" />
-              <Patch Id="BOXp8F4BjzKLpypalJ5ZBj" ManuallySortedPins="true">
-                <Patch Id="EfaPzn7XKgDP93hsoxvwgG" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="TzGW1bPRmq8MEe0aMcCAlQ" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="231,357,325,19" Id="UT76EQ0TVVxPyHQK7iKjGa">
-                  <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="OrbitCamera" />
-                  </p:NodeReference>
-                  <Pin Id="SRl0wQXTcpUNRNVSYb35eU" Name="Components" Kind="InputPin" />
-                  <Pin Id="SQCMBI436aROrZDrPD8wE6" Name="Children" Kind="InputPin" />
-                  <Pin Id="AxHZFKWnD8FNhC6YCsWElA" Name="Initial Interest" Kind="InputPin" />
-                  <Pin Id="USR1zz1wrYYODNwWULjX5S" Name="Initial Yaw" Kind="InputPin" />
-                  <Pin Id="O4JbOhufSA9MLV4OXyO18d" Name="Initial Pitch" Kind="InputPin" />
-                  <Pin Id="UWIPrKBMso2NOJCeBplVc3" Name="Initial Distance" Kind="InputPin" />
-                  <Pin Id="MvDkGMukMWEPpPlJ9dfyCS" Name="Initial Vertical Field Of View" Kind="InputPin" />
-                  <Pin Id="VAczuSA1CAlNEUK7BmHH0I" Name="Projection" Kind="InputPin" />
-                  <Pin Id="U1vt6WG9DSuO3IUThdiy1W" Name="Near Clip Plane" Kind="InputPin" />
-                  <Pin Id="CmKqHK0fb16Li9TDs1XjFx" Name="Far Clip Plane" Kind="InputPin" />
-                  <Pin Id="FE9LSsipXrqNIGdxjYzraa" Name="Auto Fetch Input Source" Kind="InputPin" />
-                  <Pin Id="U1JkN4h7A5IMio6i8x2ak5" Name="Aspect Ratio" Kind="InputPin" />
-                  <Pin Id="BnNW67oZVt4PsDibgRmlqI" Name="Use Custom Aspect Ratio" Kind="InputPin" />
-                  <Pin Id="BLTRt7MQIGbOwCEzTjvT8x" Name="Show Helper" Kind="InputPin" DefaultValue="False">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Boolean" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="Pj2OC9qxUpTOM8rmwE8LqW" Name="Projection Matrix" Kind="InputPin" />
-                  <Pin Id="GjakRPCdLKYOwj7fycaaol" Name="Reset" Kind="InputPin" />
-                  <Pin Id="HKiYF0870PwLEOxuX6BEHO" Name="Enabled" Kind="InputPin" />
-                  <Pin Id="PiskC1HrREWPeP5gbOPiRK" Name="Output" Kind="OutputPin" />
-                  <Pin Id="Vay32S15mODLKULv03a8lH" Name="Position" Kind="OutputPin" />
-                  <Pin Id="TSMVTGws13EPD2lIDhjUuY" Name="Frustum" Kind="OutputPin" />
-                  <Pin Id="OYaqKfmeVxDPEyhmNxOPwO" Name="Inverse View" Kind="OutputPin" />
-                  <Pin Id="SBlu60yIW2CMVI7gWkwPwc" Name="Camera Component" Kind="OutputPin" />
-                </Node>
-              </Patch>
-            </Node>
-            <Node Bounds="111,201,58,19" Id="OXVMDEg5wQuQPmIQ7MyIkk">
-              <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="EditMode" />
-              </p:NodeReference>
-              <Pin Id="HQVkGtRq547MI1DtwpfIgn" Name="Output" Kind="OutputPin" />
-              <Pin Id="Ic7bjwHQWb8OJiRYDVKRmW" Name="Enabled" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="Mgm2SP6crd2OwlXiXvxpxG" Bounds="268,122" />
-            <Node Bounds="164,160,72,19" Id="VQcSHUyW9sAQQB0lPxq39s">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-              </p:NodeReference>
-              <Pin Id="DhlG1on9VRRP9edyLRFbjq" Name="X" Kind="InputPin" />
-              <Pin Id="Rg9gwnVKLlAN8xSoVZFoxu" Name="Result" Kind="OutputPin" />
-              <Pin Id="GzLhPFpt8KrLt3ZlGYl8sB" Name="Not Assigned" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="204,233,30,19" Id="CWJ7ORzMdyEMZMTQ520TwA">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="OR" />
-              </p:NodeReference>
-              <Pin Id="IgSDAHKZ51VNKXn7omRcBD" Name="Input" Kind="StateInputPin" />
-              <Pin Id="MZX3hscbAQ5NgTQ286fiP4" Name="Input 2" Kind="InputPin" />
-              <Pin Id="OhyksvjAH5HQVzr45h1tsQ" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="UxBrJBRz4R5N1aWOucNulS" Bounds="332,237" />
-            <Node Bounds="219,277,37,19" Id="UQMQ7zUJQC2Ngmp0RthaBK">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AND" />
-              </p:NodeReference>
-              <Pin Id="MG0RXj2xKeiLXVMpU81nGE" Name="Input" Kind="StateInputPin" />
-              <Pin Id="RZcPzDkhKQlOiMCUROHHUS" Name="Input 2" Kind="InputPin" />
-              <Pin Id="HIzXJnFjKUpLMJkeJkppxw" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="My4RXiDNYRHL0EikfSvwBe" Bounds="583,233" />
-            <ControlPoint Id="GNnhRyjDMzhLS05WBzBj3o" Bounds="119,459" />
-            <ControlPoint Id="LlilnQMRjNeMhLcWpZzuCv" Bounds="575,825" />
-            <ControlPoint Id="R85dD4AxRJgLwbNmRRIVAp" Bounds="766,825" />
-            <ControlPoint Id="UGYxXfahOljM4RdVIYVylo" Bounds="386,831" />
-            <ControlPoint Id="Ft1UNykO537ML9dd9ffqp0" Bounds="722,422" />
-            <ControlPoint Id="R6q2E0qih0jQSa3qbOeBDG" Bounds="741,447" />
-            <ControlPoint Id="HdmAB4QN5GUOo9VSxniX7u" Bounds="683,381" />
-            <ControlPoint Id="PwZUcLraC86NQqMZQv1erW" Bounds="703,400" />
-            <ControlPoint Id="LP0bsuwt4U9P7GAk8rpeQ8" Bounds="802,512" />
-            <ControlPoint Id="P8F3b26ccnoMOo4gefRWh7" Bounds="272,831" />
-            <ControlPoint Id="BkG2y5nxVwSNQHDXHLnby2" Bounds="782,492" />
-            <ControlPoint Id="JeB9IlTEi9OOGv6lMVqXW6" Bounds="641,305" />
-            <ControlPoint Id="R3VE5Pv6yIUOFdjGmamoEX" Bounds="762,469" />
-            <ControlPoint Id="K9tTs9KphCVPHGX5MhzBzY" Bounds="660,336" />
-            <ControlPoint Id="Vb2tZ8tJCzcP0J8wSbWtuu" Bounds="981,787" />
-            <Node Bounds="480,535,325,19" Id="E2sW36lhORjMBK2a6BOQ3L">
-              <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="ShadowCatcher" NeedsToBeDirectParent="true" />
-                <Choice Kind="ProcessAppFlag" Name="DefaultCompositorSetup" />
-              </p:NodeReference>
-              <Pin Id="AC0piEHiiUKPSmlTrW4hsY" Name="Scene Instance" Kind="InputPin" />
-              <Pin Id="PLDgRv3E5j0LNMe7QTIHSY" Name="Camera" Kind="InputPin" />
-              <Pin Id="VGOF4WkJr9YNP9qXqVBDkZ" Name="Clear" Kind="InputPin" />
-              <Pin Id="Ul1xEAW7iHKM7VaNIBpNpE" Name="Clear Color" Kind="InputPin" />
-              <Pin Id="CpPjW9GvGxEPBLgOh6GhfJ" Name="Post Effects" Kind="InputPin" />
-              <Pin Id="Roo9UJf0s9gNuZixP8iGMk" Name="Enable Default Post Effects" Kind="InputPin" />
-              <Pin Id="GoFAEimCuCBPUYlopqHfZk" Name="Render Group Mask" Kind="InputPin" />
-              <Pin Id="HXluJD5fOOxOcuXam2ErgH" Name="Edit Mode" Kind="InputPin" />
-              <Pin Id="P896suPCv7oNKyBoFmXGjY" Name="Model Effect Name" Kind="InputPin" />
-              <Pin Id="A0iwuTD1jAMOFBcX5An0Np" Name="Additional Scene Renderers" Kind="InputPin" />
-              <Pin Id="A6AaE2u8nrFQRle7hWqgxy" Name="MSAALevel" Kind="InputPin" />
-              <Pin Id="IVJgqjbX1ilPdESQ9LSDmq" Name="MSAAResolver" Kind="InputPin" />
-              <Pin Id="RTltcLX1DV9QA0Dy9ox5NE" Name="Light Shafts" Kind="InputPin" />
-              <Pin Id="NHsDeyeePR7NyUvf5lmCkR" Name="VR Settings" Kind="InputPin" />
-              <Pin Id="VgfAAItLOCUOWCLWR5nRei" Name="Viewport Settings" Kind="InputPin" />
-              <Pin Id="TyVodQyahVlOTUQGTOoaRn" Name="Subsurface Scattering Blur Settings" Kind="InputPin" />
-              <Pin Id="VXxGpfquwYqMEDpuvJ58bP" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" />
-              <Pin Id="IAwOtTKWW2QMp4fQx6t8yu" Name="Output" Kind="OutputPin" />
-              <Pin Id="VWhBa2vr4KjMX6lvoK1QiA" Name="Compositor" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="IRr5NpQhqMjODCDvlktCv3" Bounds="152,445" />
-            <Pad Id="MjfwJeLm2STOpGNQgXEBQf" Bounds="1050,782,163,64" ShowValueBox="true" isIOBox="true" Value="&lt;-Very small change just to add Compositor output">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-          </Canvas>
-          <Link Id="BiOfNlullgZQKgiJG7Vtpy" Ids="H4N5RTLsQmfQOcWiGUkq3J,Vr3Eepuc1x9L068NnRCIJ3" IsHidden="true" />
-          <Link Id="HnfIP4PqVW5MiMoYMMcib1" Ids="BiDA88lCL7TLSCnioFjAk6,R7uxuTPSvfHOXKOO7Zzb8y" IsHidden="true" />
-          <Link Id="HNjwthdTJDWLgncQqFeaEd" Ids="LyanXPfQORoNDNpA6kPqtA,HlhjITIPQDtMBxf78y6kOQ" IsHidden="true" />
-          <Link Id="Jwa3uxaqWbuONpVQ7SyfuA" Ids="J2tLUPKnRxWN2NlmOFaDTW,BiDA88lCL7TLSCnioFjAk6" />
-          <Link Id="Ct2yFRuORWjPCadjV21eS8" Ids="VcC0zidz0HOQAmetm1laM3,AFtzLwpF5TnMoWuRI4XPkR" />
-          <Link Id="HTp3KDVmJ7VNQUPa9rEOKp" Ids="PletlJR9xwWQW20lgGOuA0,VcC0zidz0HOQAmetm1laM3" IsHidden="true" />
-          <Link Id="U1Ij7jZoHpQLwGQ4Yr5XvN" Ids="FIkOY40RnYpQKAItzwVPbN,IegoiSJZRtWNpUlpNhaLhx" />
-          <Link Id="RR5Lt24uzOBPYnnInDRCMV" Ids="KhGjJRBaJFROXNjPiqWUWV,FIkOY40RnYpQKAItzwVPbN" IsHidden="true" />
-          <Link Id="J2ym0nVQjkOLjyObbG7blw" Ids="QgqDLhvyoErOBw46BYOOrx,FX2QvItsl7zL8V7nCUdNLl" />
-          <Link Id="GcLLfo0sG59Ndg4cx1KTV1" Ids="QbVJTKmCXntMBKKnSo1zhh,QgqDLhvyoErOBw46BYOOrx" IsHidden="true" />
-          <Link Id="RhFjuCNKsR6Ooi427hksKa" Ids="Q5CrDi5eRSAPnDtPUZ4QlO,DNYs897NyYPP8Cxk9DXZ7h" />
-          <Link Id="H0InZ3Afqb1QKWZPP7zy6h" Ids="ELDwSJXxii5LI7l75jQgsZ,Q5CrDi5eRSAPnDtPUZ4QlO" IsHidden="true" />
-          <Link Id="N6znimjKND0P8H03xBmBVt" Ids="Vr3Eepuc1x9L068NnRCIJ3,N5ExraUJAy7P9ZvokNTGl1" />
-          <Link Id="RegDVMar59YMERztFD4fhp" Ids="HlhjITIPQDtMBxf78y6kOQ,IaqIPclqpmpOhFTumfLMv9" />
-          <Link Id="RrqZlJ1XOLvNFRWBCGgaxQ" Ids="HjL5AM6E1tNQO3AOPE2OCj,DbmYd1et8mGPy5DfvTOFTa" IsHidden="true" />
-          <Link Id="QlO5DDDQeyfLlQ9d0xvHrt" Ids="DbmYd1et8mGPy5DfvTOFTa,SCZ78TQF4J7OLHxtg736eh" />
-          <Link Id="LPsThfqAqM8M9hhMYI00K2" Ids="U3hLnM5y1TYPCiPlIiZCsG,LpFlwCmClEoL8QhFb3KLzl" IsHidden="true" />
-          <Link Id="VdjgpT7s0FXPys2xEk9W3O" Ids="DGhZil6SiRyOCJF56ztTdF,PS1NGKmNL3VMd5ZwWXdFWY" IsHidden="true" />
-          <Link Id="IeTcYeIbjYKNN03Vg5Ffz0" Ids="TYwEi5hWj92L6TVblrB67a,MBaCWjmoenjOPkpbwEe7gu" IsHidden="true" />
-          <Link Id="PUQALwq7oIsM8Lb6WYm9lr" Ids="O63MjJbMur5O5Ljrx7DqiG,LMK1e7xaz8PQOlZINwG5Dn" IsHidden="true" />
-          <Link Id="QY7pdmqlITQO1QOf0ACmyk" Ids="PyhOOcFSrUAO4nrpyzA9Ga,NMcfxAiJNaqNi23dqWX7hz" IsHidden="true" />
-          <Link Id="PD0UKOYDYDCO1KpGFhlJmY" Ids="RsowSwu77cMMlbLyjXZHe7,DtW73QY6QtsMY3cks71a44" IsHidden="true" />
-          <Link Id="RbekXNFxgcfNdrteBGqmlC" Ids="KkjV4RIf8aqMFeexhPwTW6,B8Iki5MNfdGM9IenjEN3kU" IsHidden="true" />
-          <Link Id="MHQQKO0KgAeLZUT1U0fP45" Ids="DtW73QY6QtsMY3cks71a44,VqEWI6xmQecNe42aq7rQcr" />
-          <Link Id="FK20nJjkllUQY1s35A2t7q" Ids="NMcfxAiJNaqNi23dqWX7hz,LMu34VpPUUrQWQfw3Yasii" />
-          <Link Id="UPHQjJCubS3MtDPFrRfufo" Ids="B8Iki5MNfdGM9IenjEN3kU,I4WO1WdOMZtNwgvjTeb8nd" />
-          <Link Id="JFsFe12o61RNUhjbuANR8j" Ids="KIuvOSm9seXMcr9IPYkJ0k,Czm9n0kxdy9MTa1b9ELkHA" IsHidden="true" />
-          <Link Id="BxGHzyBpjxPL94SqMkQJRK" Ids="VkY6KD1MLUsPcTB1aoyzCA,Mgm2SP6crd2OwlXiXvxpxG" IsHidden="true" />
-          <Link Id="Hf3lG7nEQpiLbyZPHYy3tm" Ids="F6W14iUChFdO4GnyR67zOE,UMsdDKGcoZZQLA7CPhBPNL" IsFeedback="true" />
-          <Link Id="VrtV6hItiDQNJJKbaLlkzO" Ids="Ic7bjwHQWb8OJiRYDVKRmW,IgSDAHKZ51VNKXn7omRcBD" />
-          <Link Id="KOyQXVS16kKMZwkQCHqozU" Ids="OhyksvjAH5HQVzr45h1tsQ,MG0RXj2xKeiLXVMpU81nGE" />
-          <Link Id="PJ506Vwn188OR8ACMgTFHQ" Ids="PiskC1HrREWPeP5gbOPiRK,UMsdDKGcoZZQLA7CPhBPNL" />
-          <Link Id="OFqc9Npe9QxLHG0uzavORa" Ids="GdzJypg3YXxMax9C6xczlm,UxBrJBRz4R5N1aWOucNulS" IsHidden="true" />
-          <Link Id="Uxw3sRmuNPnMGnZgUnjxU3" Ids="HIzXJnFjKUpLMJkeJkppxw,BrQYfjfXeyiP5gtHBURsaI" />
-          <Link Id="FmrJvqZZgMfMau6PMDNmgX" Ids="UxBrJBRz4R5N1aWOucNulS,RZcPzDkhKQlOiMCUROHHUS" />
-          <Link Id="TAKIR70GpsTQWMdkmYpfTt" Ids="GXicodt0PGGPwDgKa4sDCc,My4RXiDNYRHL0EikfSvwBe" IsHidden="true" />
-          <Link Id="QkWO60ytRZ4QLQGOmZI5Hv" Ids="Mgm2SP6crd2OwlXiXvxpxG,DhlG1on9VRRP9edyLRFbjq" />
-          <Link Id="QROiPKMbpJTPW2jibKCpoi" Ids="GzLhPFpt8KrLt3ZlGYl8sB,MZX3hscbAQ5NgTQ286fiP4" />
-          <Link Id="BNYhTIobcg0PdtDlRXaM0n" Ids="Mgm2SP6crd2OwlXiXvxpxG,F6W14iUChFdO4GnyR67zOE" />
-          <Link Id="UfDmKQYJ1TfOQ8SWJ5Oo2p" Ids="HQVkGtRq547MI1DtwpfIgn,GNnhRyjDMzhLS05WBzBj3o,BN1zEn2leYrOLrWP2XZt0m" />
-          <Link Id="KmAqlBkwnsoNuLUSlUyHwr" Ids="LlilnQMRjNeMhLcWpZzuCv,SoXUfPtQYoNPuvDb0Tz6ck" IsHidden="true" />
-          <Link Id="FRE8wXZ34vNNCO6lFwavQQ" Ids="R85dD4AxRJgLwbNmRRIVAp,VZFzUGj0M42OA2tkE98iq6" IsHidden="true" />
-          <Link Id="CAcadAkBcirLChmVdTT56T" Ids="AguO2FeDipvPshhFwksta2,R85dD4AxRJgLwbNmRRIVAp" />
-          <Link Id="PMzBlh59necNLs0U5vwIrD" Ids="PO7Ph4Ne6HIOUpDVJXB3t3,LlilnQMRjNeMhLcWpZzuCv" />
-          <Link Id="SUNh1VeNdd3L1m4kvAzERc" Ids="UGYxXfahOljM4RdVIYVylo,Hv314VC5RPkLXUQm01gWJv" IsHidden="true" />
-          <Link Id="QLw11mPulVXNOSt7PJyECn" Ids="DzBERsNeUqyNk5164IYFi3,UGYxXfahOljM4RdVIYVylo" />
-          <Link Id="EOHmjvcwbThO973Tv33TJj" Ids="DmeeSX4evy9LZfZU5EYCUs,Ft1UNykO537ML9dd9ffqp0" IsHidden="true" />
-          <Link Id="LlsEBaZtxebOWo7RVFZBpf" Ids="TTvZdABpaJmMUS1K9q3Pnk,R6q2E0qih0jQSa3qbOeBDG" IsHidden="true" />
-          <Link Id="HsOkzxnDznVOm7AVvJaXmr" Ids="KHxkuI3smuBQX0S0eKwXgG,HdmAB4QN5GUOo9VSxniX7u" IsHidden="true" />
-          <Link Id="TgucB4ug325NYsqF7wIoBc" Ids="Ry7g5iRqAOjPdEovTDoHQs,PwZUcLraC86NQqMZQv1erW" IsHidden="true" />
-          <Link Id="EeRxpgUgmTQOQw9Zum03lU" Ids="Qn8fSebKiRHMi2X6BtbtQ1,LP0bsuwt4U9P7GAk8rpeQ8" IsHidden="true" />
-          <Link Id="MKc068EczVFPpc9cuNIgQe" Ids="P8F3b26ccnoMOo4gefRWh7,DUePijVVB95PbLtN5lXwcg" IsHidden="true" />
-          <Link Id="NeB7QsTHLEkOQ7OVEvPQ5F" Ids="AdB4KTsj7fMLFc4Glpa44o,P8F3b26ccnoMOo4gefRWh7" />
-          <Link Id="I3MVvQTlcrtMwHHMz18wRB" Ids="BnStdW05CHRQV13oAjDIqd,BkG2y5nxVwSNQHDXHLnby2" IsHidden="true" />
-          <Link Id="NQpIDi6SzpDNDYb6IUZsrH" Ids="MGfeFWNWRzFNCRrWpnwPYV,JeB9IlTEi9OOGv6lMVqXW6" IsHidden="true" />
-          <Link Id="H8c8LedHMvcQVmVVUKBjnH" Ids="PGoBxs4ug7tPswUXwo8Yvi,R3VE5Pv6yIUOFdjGmamoEX" IsHidden="true" />
-          <Link Id="NK8ezE6jIeYOH6wC5P7An5" Ids="OqxiHUbMPe4NSq9pup7TKQ,K9tTs9KphCVPHGX5MhzBzY" IsHidden="true" />
-          <Link Id="FiEfmT6WPOXP3YPz5x9WW2" Ids="Vb2tZ8tJCzcP0J8wSbWtuu,RhxLxiEXUk8ML1FfZQrd1o" IsHidden="true" />
-          <Link Id="OnOftJsxuj4LXf526jRp65" Ids="UMsdDKGcoZZQLA7CPhBPNL,PLDgRv3E5j0LNMe7QTIHSY" />
-          <Link Id="OZGv7X5YxR9OwjFY5O49wS" Ids="LpFlwCmClEoL8QhFb3KLzl,AC0piEHiiUKPSmlTrW4hsY" />
-          <Link Id="I18Di4B8jGTLjrm5SlBHM6" Ids="MBaCWjmoenjOPkpbwEe7gu,VGOF4WkJr9YNP9qXqVBDkZ" />
-          <Link Id="Fx3vp5ZWv19N9pQEVayyzv" Ids="LMK1e7xaz8PQOlZINwG5Dn,Ul1xEAW7iHKM7VaNIBpNpE" />
-          <Link Id="EQxwRYjvIdwP8B67vo1etH" Ids="PS1NGKmNL3VMd5ZwWXdFWY,CpPjW9GvGxEPBLgOh6GhfJ" />
-          <Link Id="FOr3SGfrZhHLZ1Rc5g1Y5J" Ids="My4RXiDNYRHL0EikfSvwBe,Roo9UJf0s9gNuZixP8iGMk" />
-          <Link Id="QasIbDjx2vANSPqJxMUFDC" Ids="Czm9n0kxdy9MTa1b9ELkHA,GoFAEimCuCBPUYlopqHfZk" />
-          <Link Id="GhTkEIowO6IPrWQsONKTqE" Ids="JeB9IlTEi9OOGv6lMVqXW6,P896suPCv7oNKyBoFmXGjY" />
-          <Link Id="KOLs2B3iPqkP6VD5wRgGsp" Ids="K9tTs9KphCVPHGX5MhzBzY,A0iwuTD1jAMOFBcX5An0Np" />
-          <Link Id="FuioBKG14wNNCn8tGGofyI" Ids="HdmAB4QN5GUOo9VSxniX7u,A6AaE2u8nrFQRle7hWqgxy" />
-          <Link Id="Hs9zMmVIVZaNNNuXtcAx4W" Ids="PwZUcLraC86NQqMZQv1erW,IVJgqjbX1ilPdESQ9LSDmq" />
-          <Link Id="QzbqdIXW6SHP8osuzp9tVc" Ids="Ft1UNykO537ML9dd9ffqp0,RTltcLX1DV9QA0Dy9ox5NE" />
-          <Link Id="KqZw7dcvmyxNLcTmDVt57e" Ids="R6q2E0qih0jQSa3qbOeBDG,NHsDeyeePR7NyUvf5lmCkR" />
-          <Link Id="L17CS2qPWAJLUGTE3tc00e" Ids="R3VE5Pv6yIUOFdjGmamoEX,VgfAAItLOCUOWCLWR5nRei" />
-          <Link Id="QPrQ50wDLWZN3bNC2hy09C" Ids="BkG2y5nxVwSNQHDXHLnby2,TyVodQyahVlOTUQGTOoaRn" />
-          <Link Id="ETvoOGPLfvMOp1ZYLrz1m3" Ids="LP0bsuwt4U9P7GAk8rpeQ8,VXxGpfquwYqMEDpuvJ58bP" />
-          <Link Id="FVQcHDiQ1aqLaJqTFb1Cf5" Ids="VWhBa2vr4KjMX6lvoK1QiA,Vb2tZ8tJCzcP0J8wSbWtuu" />
-          <Link Id="H1mJg5QEVXjOtIT7LyDsDc" Ids="HQVkGtRq547MI1DtwpfIgn,IRr5NpQhqMjODCDvlktCv3,HXluJD5fOOxOcuXam2ErgH" />
-          <Link Id="EbmqyQvEG1HNKOcyDlNnsM" Ids="IAwOtTKWW2QMp4fQx6t8yu,MVWvk7wPPu5NN5BVK3Emo3" />
-          <ProcessDefinition Id="KgMjbT6xKlvN7NpI33et4u">
-            <Fragment Id="CvEglcgDnpRNiXHmKfCsxB" Patch="P1splCmU2ZnM8WBwokAn1s" Enabled="true" />
-            <Fragment Id="J6fKxBxIGd6LuZ1eG0eloN" Patch="I2FRoqcD5e9QblAIZUTjVo" Enabled="true" />
-            <Fragment Id="CG4shR6VM51OBTIwKK0vnC" Patch="RjoZtMlhM8OLYrvi4QQU3G" Enabled="true" />
-            <Fragment Id="Fi3vaDDWvi3NPfAlckyGDj" Patch="L06GInDqxOcMysMLCUYLa5" Enabled="true" />
-            <Fragment Id="EUE7Tk6Zuk4M0pAFeVxjDL" Patch="NnH60H1vpj1LXjQzZGv0cW" Enabled="true" />
-            <Fragment Id="D7YojaElPBzOzChKDKBFBr" Patch="Esln0lwKcmPQT2tTvSYdtb" Enabled="true" />
-            <Fragment Id="BpiKhKIbdlwPH9ir1ze9Qp" Patch="RIVvLcqNWQTL1efuCn4FWo" Enabled="true" />
-            <Fragment Id="GdcP3xnAE8fL05yRo2gH2M" Patch="IR2ZJkp6wvmN6vpvz7ONn1" Enabled="true" />
-            <Fragment Id="H0R9BqdDG1oLVpUJ2akOOi" Patch="TnpZss2GCtvMkURdUye7OM" Enabled="true" />
-            <Fragment Id="GNFa0HGMPpBM1TmwybAfFf" Patch="FcY84jjAgIIP87TL0TDEOy" Enabled="true" />
-            <Fragment Id="CNTQa1ZQ5i0Nkd9NayMOCq" Patch="FrVrZp4dabXNdVECgECMa2" Enabled="true" />
-            <Fragment Id="IhUCLayFV7yOlCuZtqn9um" Patch="Egn67SoM4kOQYjl6cs2HDq" Enabled="true" />
-            <Fragment Id="BZMjJmijyGEOIPuHe3o8uk" Patch="ABi9xJ8u7FzPdLYj3jMsLQ" Enabled="true" />
-          </ProcessDefinition>
-          <Patch Id="P1splCmU2ZnM8WBwokAn1s" Name="Create" ManuallySortedPins="true">
-            <Pin Id="PletlJR9xwWQW20lgGOuA0" Name="Bounds" Kind="InputPin" />
-            <Pin Id="KhGjJRBaJFROXNjPiqWUWV" Name="Bound to Document" Kind="InputPin" Bounds="424,767" Visibility="Optional" />
-            <Pin Id="QbVJTKmCXntMBKKnSo1zhh" Name="Dialog If Document Changed" Kind="InputPin" Bounds="446,764" Visibility="Optional" />
-            <Pin Id="ELDwSJXxii5LI7l75jQgsZ" Name="Save Bounds" Kind="InputPin" Visibility="Optional" />
-            <Pin Id="RsowSwu77cMMlbLyjXZHe7" Name="Back Buffer Format" Kind="InputPin" Visibility="Optional" />
-            <Pin Id="PyhOOcFSrUAO4nrpyzA9Ga" Name="Depth Buffer Format" Kind="InputPin" DefaultValue="D24_UNorm_S8_UInt" Visibility="Optional">
-              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
-                <Choice Kind="TypeFlag" Name="PixelFormat" />
-              </p:TypeAnnotation>
-            </Pin>
-          </Patch>
-          <Patch Id="I2FRoqcD5e9QblAIZUTjVo" Name="Update" ManuallySortedPins="true">
-            <Pin Id="U3hLnM5y1TYPCiPlIiZCsG" Name="Input" Kind="InputPin" Bounds="251,226" />
-            <Pin Id="VkY6KD1MLUsPcTB1aoyzCA" Name="Camera" Kind="InputPin" Bounds="826,560" />
-            <Pin Id="GdzJypg3YXxMax9C6xczlm" Name="Enable Default Camera" Kind="InputPin" Bounds="647,235" />
-            <Pin Id="LyanXPfQORoNDNpA6kPqtA" Name="Title" Kind="InputPin" DefaultValue="Stride">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="O63MjJbMur5O5Ljrx7DqiG" Name="Clear Color" Kind="InputPin" Bounds="596,359" />
-            <Pin Id="TYwEi5hWj92L6TVblrB67a" Name="Clear" Kind="InputPin" Bounds="577,341" />
-            <Pin Id="DGhZil6SiRyOCJF56ztTdF" Name="Post Effects" Kind="InputPin" Bounds="864,478" />
-            <Pin Id="GXicodt0PGGPwDgKa4sDCc" Name="Enable Default Post Effects" Kind="InputPin" Bounds="922,222" />
-            <Pin Id="KIuvOSm9seXMcr9IPYkJ0k" Name="Render Group Mask" Kind="InputPin" Bounds="818,356" Visibility="Optional" />
-            <Pin Id="HjL5AM6E1tNQO3AOPE2OCj" Name="Enable Keyboard Shortcuts" Kind="InputPin" Bounds="642,1" />
-            <Pin Id="MGfeFWNWRzFNCRrWpnwPYV" Name="Model Effect Name" Kind="InputPin" Bounds="870,554" Visibility="Optional" />
-            <Pin Id="OqxiHUbMPe4NSq9pup7TKQ" Name="Additional Scene Renderers" Kind="InputPin" Bounds="660,337" Visibility="Optional" />
-            <Pin Id="H4N5RTLsQmfQOcWiGUkq3J" Name="Enabled" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="R7uxuTPSvfHOXKOO7Zzb8y" Name="Output" Kind="OutputPin" Bounds="404,481" />
-            <Pin Id="RhxLxiEXUk8ML1FfZQrd1o" Name="Compositor" Kind="OutputPin" Bounds="742,875" />
-          </Patch>
-          <Patch Id="RjoZtMlhM8OLYrvi4QQU3G" Name="SetPresentInterval">
-            <Pin Id="KkjV4RIf8aqMFeexhPwTW6" MergeId="658386" Name="Present Interval" Kind="InputPin" Summary="VSync" />
-          </Patch>
-          <Patch Id="Egn67SoM4kOQYjl6cs2HDq" Name="BackBuffer">
-            <Pin Id="SoXUfPtQYoNPuvDb0Tz6ck" MergeId="130659" Name="Back Buffer" Kind="OutputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="ABi9xJ8u7FzPdLYj3jMsLQ" Name="DepthBuffer">
-            <Pin Id="VZFzUGj0M42OA2tkE98iq6" MergeId="130661" Name="Depth Buffer" Kind="OutputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="FrVrZp4dabXNdVECgECMa2" Name="InputSource">
-            <Pin Id="Hv314VC5RPkLXUQm01gWJv" MergeId="130647" Name="Input Source" Kind="OutputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="NnH60H1vpj1LXjQzZGv0cW" Name="SetLightShafts">
-            <Pin Id="DmeeSX4evy9LZfZU5EYCUs" MergeId="549640" Name="Light Shafts" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="Esln0lwKcmPQT2tTvSYdtb" Name="SetVRSettings">
-            <Pin Id="TTvZdABpaJmMUS1K9q3Pnk" MergeId="551209" Name="VR Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="IR2ZJkp6wvmN6vpvz7ONn1" Name="SetSubsurfaceScatteringBlurEffect">
-            <Pin Id="BnStdW05CHRQV13oAjDIqd" Name="Subsurface Scattering Blur Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="L06GInDqxOcMysMLCUYLa5" Name="SetMSAA">
-            <Pin Id="KHxkuI3smuBQX0S0eKwXgG" MergeId="554369" Name="MSAALevel" Kind="InputPin" DefaultValue="X4" Visibility="Optional">
-              <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
-                <Choice Kind="TypeFlag" Name="MultisampleCount" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="Ry7g5iRqAOjPdEovTDoHQs" MergeId="555947" Name="MSAAResolver" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="TnpZss2GCtvMkURdUye7OM" Name="SetBindDepthDuringTransparentStage">
-            <Pin Id="Qn8fSebKiRHMi2X6BtbtQ1" MergeId="557534" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="FcY84jjAgIIP87TL0TDEOy" Name="ClientBounds">
-            <Pin Id="DUePijVVB95PbLtN5lXwcg" MergeId="525235" Name="Client Bounds" Kind="OutputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="RIVvLcqNWQTL1efuCn4FWo" Name="SetViewportSettings">
-            <Pin Id="PGoBxs4ug7tPswUXwo8Yvi" MergeId="484258" Name="Viewport Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-        </Patch>
-      </Node>
-      <!--
-
-    ************************ DefaultCompositorSetup ************************
-
--->
-      <Node Name="DefaultCompositorSetup" Bounds="557,524" Id="GG0Ffq9RIxBQbrQzKQw4to">
-        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
-          <Choice Kind="ContainerDefinition" Name="Process" />
-        </p:NodeReference>
-        <Patch Id="DzZcnNUDItAPbspiQzwgNQ">
-          <Canvas Id="MGXkTbZ3YHBP0cj4DzsVil" CanvasType="Group">
-            <Node Bounds="341,665,465,19" Id="U8j3Sp1QqtDOAwURG7ksAw">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DefaultCompositor" />
-              </p:NodeReference>
-              <Pin Id="IK0It4X30WqNnmjy9S3rg3" Name="MSAALevel" Kind="InputPin" />
-              <Pin Id="MtLvTqm0URbNM6q3dGHFu0" Name="MSAAResolver" Kind="InputPin" />
-              <Pin Id="Tv8bkpdtQA9LEbVTnCtai1" Name="Light Shafts" Kind="InputPin" />
-              <Pin Id="H72UAv125bgLPHFpwo0Cxx" Name="VR Settings" Kind="InputPin" />
-              <Pin Id="V1kjB7X6YMEPxCHSyBwv7h" Name="Viewport Settings" Kind="InputPin" />
-              <Pin Id="QE7K6P0kW6qOjPB2c7Xwen" Name="Subsurface Scattering Blur Settings" Kind="InputPin" />
-              <Pin Id="R05k9IH8yboLrUhXj1ZbK6" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" />
-              <Pin Id="AZq47Q6pK56PEDE6tAD4Y6" Name="Camera" Kind="InputPin" />
-              <Pin Id="EC60dmtTsszMoxr1cU1NX4" Name="Clear" Kind="InputPin" />
-              <Pin Id="DOcXuUoEWx4PJCHKDAdSdM" Name="Clear Color" Kind="InputPin" />
-              <Pin Id="FeqSJcN7pYiPqKkoGFm1m3" Name="Post Effects" Kind="InputPin" />
-              <Pin Id="Cxfvc8ImF1SPuEJAW9yYnx" Name="Model Effect Name" Kind="InputPin" />
-              <Pin Id="EnvNGYQKfdaObDxnjEwjpy" Name="Render Group Mask" Kind="InputPin" />
-              <Pin Id="LBXtAyjHqipMa6JLoSTYdK" Name="Helpers Renderer" Kind="InputPin" />
-              <Pin Id="S7jmVhvS9cELTFN4D3brY9" Name="Additional Scene Renderers" Kind="InputPin" />
-              <Pin Id="NCRZDIwdYbLMRtcrCi0T5s" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="374,284,431,91" Id="FBaJLd9Ff78OJMc43wzILU">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:NodeReference>
-              <Pin Id="Dw0eQxfVqeyOKJHjm5LktS" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="KWeEc3JyxN7M5ZjDwAezNi" Bounds="388,290" Alignment="Top" />
-              <ControlPoint Id="I0VzPyWfU39PrFXvFd2MHw" Bounds="390,369" Alignment="Bottom" />
-              <Patch Id="Mis8SCLnj51N1YX9LlgZsx" ManuallySortedPins="true">
-                <Patch Id="JFzmrp9FUj8NKeSTnTbCdm" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="H2LDppRA98gNUY7W153QWW" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="388,320,405,19" Id="NXfFlOjBSs0MaEOGq8ZDor">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="ProcessAppFlag" Name="PostFX" />
-                  </p:NodeReference>
-                  <Pin Id="AkLwc16g3vDLi79zujZE5L" Name="Ambient Occlusion" Kind="InputPin" />
-                  <Pin Id="StS09yi5f7oN7sTIHccsxE" Name="SetAmbientOcclusion" Kind="InputPin" />
-                  <Pin Id="UpUDdPtcJFfLU0bXjwUNn0" Name="Local Reflections" Kind="InputPin" />
-                  <Pin Id="MKZCJH98lisMVZsdMBa33W" Name="SetLocalReflections" Kind="InputPin" />
-                  <Pin Id="M0bzY8s6xrtMtIsHIr4srC" Name="Depth Of Field" Kind="InputPin" />
-                  <Pin Id="CfLWxDjLKemMlYsCmvxnIN" Name="SetDepthOfField" Kind="InputPin" />
-                  <Pin Id="KXVbUngE9X6LF8KrCdSind" Name="Fog" Kind="InputPin" />
-                  <Pin Id="AzgtNVVC9YgN7imJUYVUag" Name="Outline" Kind="InputPin" />
-                  <Pin Id="PHTtnefg2ECQZnjSr0Tl6K" Name="Bright Filter" Kind="InputPin" />
-                  <Pin Id="TDSt2gH9MKeQcBthinwUqK" Name="SetBrightFilter" Kind="InputPin" />
-                  <Pin Id="LPyZwUpLyiJPE1kppZVCI9" Name="Bloom" Kind="InputPin" />
-                  <Pin Id="PVWY0UAerdILPDrbzwDcfJ" Name="SetBloom" Kind="InputPin" />
-                  <Pin Id="QEdIjsBAZO2NSOMmuyhMtR" Name="Light Streak" Kind="InputPin" />
-                  <Pin Id="Q6Kv7ErB91QMmOViWbg3xD" Name="SetLightStreak" Kind="InputPin" />
-                  <Pin Id="JLUlimURuvuPEFajYNaV9F" Name="Lens Flare" Kind="InputPin" />
-                  <Pin Id="UIluqanLkmlONvYtvHwrln" Name="SetLensFlare" Kind="InputPin" />
-                  <Pin Id="VMIvSNvP3KpO130URyHa2E" Name="Color Transforms" Kind="InputPin" />
-                  <Pin Id="De58PWgMGjaPF5xuWaYGPs" Name="Enable Default ToneMap" Kind="InputPin" />
-                  <Pin Id="M1ryrAqS5XINmFC1kA9KUV" Name="SetColorTransforms" Kind="InputPin" />
-                  <Pin Id="Obkyj6PL0BmOKH6Sbl96Dm" Name="Antialiasing" Kind="InputPin" />
-                  <Pin Id="NzcnYyO1DHZMT2lovyd4Ju" Name="SetAntialiasing" Kind="InputPin" />
-                  <Pin Id="JHpewW0qivoPIdmT3itFZN" Name="Output" Kind="OutputPin" />
-                </Node>
-              </Patch>
-            </Node>
-            <ControlPoint Id="JuDPVwOueO8QLgEAn7O4z8" Bounds="385,101" />
-            <Node Bounds="225,702,121,19" Id="TpGmt1a0WRxLJHw1iLAvNR">
-              <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.Nodes">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="SceneInstanceRenderer" />
-              </p:NodeReference>
-              <Pin Id="GODWNw92JobNE4JFAbWymA" Name="Scene Instance" Kind="InputPin" />
-              <Pin Id="TezNDjnkf4KNvHWembxBtj" Name="Graphics Compositor" Kind="InputPin" />
-              <Pin Id="VkWQF53UhDaQHGisyKNlYd" Name="Output" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="VSQfEr0q4aLNE2CiUqHhKk" Bounds="226,429" />
-            <ControlPoint Id="ShHzqAiZzltMDAgTuMuoze" Bounds="227,765" />
-            <ControlPoint Id="DDIirgSX3FKPjrQx955cFC" Bounds="301,535" />
-            <ControlPoint Id="BT5xThiRZZfNjj4Pwu6Mdj" Bounds="345,555" />
-            <ControlPoint Id="Tqy5LVPM3qXLv72pHwXffk" Bounds="443,471" />
-            <ControlPoint Id="TDLOXFZe6jrP4AP7fGinjn" Bounds="233,509" />
-            <Node Bounds="392,153,65,19" Id="Gpb1pREjNBJPf0iHX74R72">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-              </p:NodeReference>
-              <Pin Id="TIZgTMqSGHuOPnkEygddMa" Name="X" Kind="InputPin" />
-              <Pin Id="PqUW7uuZsWzMXKwlm3mM0u" Name="Result" Kind="OutputPin" />
-              <Pin Id="FeW2YtQlU4yLeXgTwpxx06" Name="Not Assigned" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="374,237,30,19" Id="JAyFeQwpm5sOEZ9G2u7OKV">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="OR" />
-              </p:NodeReference>
-              <Pin Id="C8y4IcwM7d7PVtleYAO1lw" Name="Input" Kind="StateInputPin" />
-              <Pin Id="M65iS69917FPIhUb3AsPI1" Name="Input 2" Kind="InputPin" />
-              <Pin Id="NxbKE9R79LPOKMQuTZ510i" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="OK75hO8c2OmPcgX0xqhSj8" Bounds="494,143" />
-            <Node Bounds="452,193,37,19" Id="RYshecDGwY0MglztsVT3Nz">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AND" />
-              </p:NodeReference>
-              <Pin Id="Rr8d9SiUg9DNHUbCdGQmha" Name="Input" Kind="StateInputPin" />
-              <Pin Id="RqTlE52zkzyPH0f9DPE8hI" Name="Input 2" Kind="InputPin" />
-              <Pin Id="G8pMUOLXdnvNtzfxD0aI2J" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="VNuZ1VoGkJWOeDtIcOhNtO" Bounds="220,169" />
-            <Node Bounds="257,200,52,26" Id="PWbpJ1ZSQktMNyQcjecYaG">
-              <p:NodeReference LastCategoryFullName="Stride.Input.EditMode" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Enabled" />
-                <CategoryReference Kind="ClassType" Name="EditMode" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="GPhgvNaE6PjM8PHSnnbsQA" Name="Input" Kind="StateInputPin" />
-              <Pin Id="DsqxPOnFlk5QI5ZHQk2QYX" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="QqaXdrtwhATLeLUoQxLFPf" Name="Enabled" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="DOIhb1vvFx5Pn2hdjoqKNF" Bounds="609,524" />
-            <Node Bounds="519,542,92,19" Id="PUdheYsDk6GQCP0Z6bXhnW">
-              <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="HelpersRenderer" />
-              </p:NodeReference>
-              <Pin Id="EdHEkv5FoVCO0SE80kzXJM" Name="Scene" Kind="InputPin" />
-              <Pin Id="Vmac0UU71nTO2PWN5JzQoV" Name="EditMode" Kind="InputPin" />
-              <Pin Id="Db7nuYDzdJUP0ipIBuYSFw" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="CEbSjYLOMQ9QOa1xjLPd2i" Bounds="765,471" />
-            <ControlPoint Id="Uj6Y8V3xKw5OWxPC6hHwBR" Bounds="787,497" />
-            <ControlPoint Id="ST2VkbcON4ZL4Rph70g6tF" Bounds="735,419" />
-            <ControlPoint Id="JRj9t0N4SXZOdsDZKeXGfV" Bounds="745,446" />
-            <ControlPoint Id="FU8gNtPXflCM7J8BqE03Rr" Bounds="828,580" />
-            <ControlPoint Id="SAj09ZMmInJNk28KBGn017" Bounds="812,553" />
-            <ControlPoint Id="K2z8Q9r3OXhQI10Fqy92Ch" Bounds="417,566" />
-            <ControlPoint Id="E21GwizdwKPPXGPY3Zj35l" Bounds="799,526" />
-            <ControlPoint Id="BY77hhOsFxzPXMDyZMTgXv" Bounds="803,629" />
-            <ControlPoint Id="NFtVECDYpguLiQhC3gSYEg" Bounds="448,748" />
-          </Canvas>
-          <Link Id="Tfoc5in5rYlOloCmZ94dCo" Ids="PnhamUm3dI3ORORb6EEGM2,JuDPVwOueO8QLgEAn7O4z8" IsHidden="true" />
-          <Link Id="J6DMypj2VhOOc3FaD8v1SV" Ids="KWeEc3JyxN7M5ZjDwAezNi,I0VzPyWfU39PrFXvFd2MHw" IsFeedback="true" />
-          <Link Id="QkrEYsNNuXcLE0SoEjMzOf" Ids="JuDPVwOueO8QLgEAn7O4z8,KWeEc3JyxN7M5ZjDwAezNi" />
-          <Link Id="M5TeDHxTFLuNBA3XCl0F2i" Ids="NCRZDIwdYbLMRtcrCi0T5s,TezNDjnkf4KNvHWembxBtj" />
-          <Link Id="NpZ9HUjh4a7QdPqDDcQGs5" Ids="VSQfEr0q4aLNE2CiUqHhKk,GODWNw92JobNE4JFAbWymA" />
-          <Link Id="QFHR5eFcjyxM3D4kj29PMm" Ids="H3Cr7UIBlvgLWWq0HYZXay,VSQfEr0q4aLNE2CiUqHhKk" IsHidden="true" />
-          <Link Id="RlZk5xt0bfILF31WS3UAcJ" Ids="VkWQF53UhDaQHGisyKNlYd,ShHzqAiZzltMDAgTuMuoze" />
-          <Link Id="BgWYFZTSACHMr3MLo4QmjF" Ids="ShHzqAiZzltMDAgTuMuoze,CZ7CDZVnvkcLuhJ8fsXrLR" IsHidden="true" />
-          <Link Id="Gnz0RKF7eePQEbnJXOUnWx" Ids="I0VzPyWfU39PrFXvFd2MHw,FeqSJcN7pYiPqKkoGFm1m3" />
-          <Link Id="F3g3rlwG1EOOAvg6dB66kW" Ids="DDIirgSX3FKPjrQx955cFC,EC60dmtTsszMoxr1cU1NX4" />
-          <Link Id="FFsYABKsFplMUTToKkC4ov" Ids="HEOI7Gbq4lPQGKK88qY4xw,DDIirgSX3FKPjrQx955cFC" IsHidden="true" />
-          <Link Id="J2GXrVNygQHOZiUVOmILvN" Ids="BT5xThiRZZfNjj4Pwu6Mdj,DOcXuUoEWx4PJCHKDAdSdM" />
-          <Link Id="TtFWJY9tQzIMhb7aYLxX6g" Ids="DnP3tPpt07pNxPwuSyOYao,BT5xThiRZZfNjj4Pwu6Mdj" IsHidden="true" />
-          <Link Id="ARRGusexOwTLHGVY9QygrE" Ids="Tqy5LVPM3qXLv72pHwXffk,EnvNGYQKfdaObDxnjEwjpy" />
-          <Link Id="Fkz8rnkwdqNL0wu8kXIGG0" Ids="UWL02voMskdQDB4nhrvoJ0,Tqy5LVPM3qXLv72pHwXffk" IsHidden="true" />
-          <Link Id="Mrik1aev1MmLkWrOY32Xsm" Ids="TDLOXFZe6jrP4AP7fGinjn,AZq47Q6pK56PEDE6tAD4Y6" />
-          <Link Id="VJTmpjY6GjtNRQWh0dtquS" Ids="HnaIu5sc1qHOyD8pOQ6vGU,TDLOXFZe6jrP4AP7fGinjn" IsHidden="true" />
-          <Link Id="E1O37C0wr5UMpDGU7BIWqW" Ids="TKyZy1DO0BSMoNfKTlcHsx,OK75hO8c2OmPcgX0xqhSj8" IsHidden="true" />
-          <Link Id="EOIPVSVOdzbL0PnGS56LOG" Ids="OK75hO8c2OmPcgX0xqhSj8,RqTlE52zkzyPH0f9DPE8hI" />
-          <Link Id="Mzz8xeMVfE0L3YeniwzuGK" Ids="JuDPVwOueO8QLgEAn7O4z8,TIZgTMqSGHuOPnkEygddMa" />
-          <Link Id="GWaTXeFA8ztM3lL6iUo73U" Ids="NxbKE9R79LPOKMQuTZ510i,Dw0eQxfVqeyOKJHjm5LktS" />
-          <Link Id="CD6zZC4Vci8L1WZptpDz6Y" Ids="FeW2YtQlU4yLeXgTwpxx06,Rr8d9SiUg9DNHUbCdGQmha" />
-          <Link Id="CGUlKWR80EVMEw5Zm8IZ4x" Ids="G8pMUOLXdnvNtzfxD0aI2J,M65iS69917FPIhUb3AsPI1" />
-          <Link Id="QvBETDjtR1MONy1p3Aoqrg" Ids="VNuZ1VoGkJWOeDtIcOhNtO,GPhgvNaE6PjM8PHSnnbsQA" />
-          <Link Id="BuDLrvzEUOmMg4xzR848Iv" Ids="QqaXdrtwhATLeLUoQxLFPf,C8y4IcwM7d7PVtleYAO1lw" />
-          <Link Id="KvxiKCCIM9xLqJ2eKDn2HF" Ids="DOIhb1vvFx5Pn2hdjoqKNF,Vmac0UU71nTO2PWN5JzQoV" />
-          <Link Id="Ubed8O1XgB4Lqvixy7iZOB" Ids="Db7nuYDzdJUP0ipIBuYSFw,LBXtAyjHqipMa6JLoSTYdK" />
-          <Link Id="SO8HLrVbV0HPabSsKP3cQ0" Ids="VSQfEr0q4aLNE2CiUqHhKk,EdHEkv5FoVCO0SE80kzXJM" />
-          <Link Id="GhtClv7tipqLmkGYOcsk2X" Ids="BE7nl5ySoKIPzRLKGSIBXE,DOIhb1vvFx5Pn2hdjoqKNF" IsHidden="true" />
-          <Link Id="Cxd4d2ucnl4NUnGZN5hwzR" Ids="BE7nl5ySoKIPzRLKGSIBXE,VNuZ1VoGkJWOeDtIcOhNtO" IsHidden="true" />
-          <Link Id="RC7VKvKiCreNzuqYQhtNSl" Ids="I40N3ISJ8ugLDYNUiGF3nF,CEbSjYLOMQ9QOa1xjLPd2i" IsHidden="true" />
-          <Link Id="AKqFqDunGchM0MwAqTlWE8" Ids="HbMHcxBKWHiN8AXNP4A41a,Uj6Y8V3xKw5OWxPC6hHwBR" IsHidden="true" />
-          <Link Id="DeNBqEG50u7NiMQAcvvuYm" Ids="BucO8WUpMLuMBG6umnqdug,ST2VkbcON4ZL4Rph70g6tF" IsHidden="true" />
-          <Link Id="IbMSGokA6TCLWVvekvv7n1" Ids="DWoww3yGz7oMmNMqk9K7gr,JRj9t0N4SXZOdsDZKeXGfV" IsHidden="true" />
-          <Link Id="OBLXaAGzN7EPZylkfePYdN" Ids="TGozGkqUMfPOKgmYSd6s80,FU8gNtPXflCM7J8BqE03Rr" IsHidden="true" />
-          <Link Id="J8D9zaxX5tnN5dT2puqZsP" Ids="ST2VkbcON4ZL4Rph70g6tF,IK0It4X30WqNnmjy9S3rg3" />
-          <Link Id="D5lQyWE6Y0dPeHEId3mPT1" Ids="JRj9t0N4SXZOdsDZKeXGfV,MtLvTqm0URbNM6q3dGHFu0" />
-          <Link Id="Sk6xbqLmW3XOcix7c9eNfs" Ids="FU8gNtPXflCM7J8BqE03Rr,R05k9IH8yboLrUhXj1ZbK6" />
-          <Link Id="B1ND5zCRCunNVnFs25EdJS" Ids="Uj6Y8V3xKw5OWxPC6hHwBR,H72UAv125bgLPHFpwo0Cxx" />
-          <Link Id="IxBdgNju8PZMpC35FNaY4S" Ids="CEbSjYLOMQ9QOa1xjLPd2i,Tv8bkpdtQA9LEbVTnCtai1" />
-          <Link Id="UmxqirATuMYMjhxotMwKrT" Ids="JHpewW0qivoPIdmT3itFZN,I0VzPyWfU39PrFXvFd2MHw" />
-          <Link Id="BmgeD6l9OErNQLlkpS6xny" Ids="SAj09ZMmInJNk28KBGn017,QE7K6P0kW6qOjPB2c7Xwen" />
-          <Link Id="EuIpqC1nYU3NaMvjrfifOq" Ids="MNBE9JXjJ4bPG1lo5HjDRi,SAj09ZMmInJNk28KBGn017" IsHidden="true" />
-          <Link Id="AsrSSrIw1aLNk6xORAlcE3" Ids="I5Q4LWrlGjnLGAwEqTmabV,K2z8Q9r3OXhQI10Fqy92Ch" IsHidden="true" />
-          <Link Id="EXbGFqgNDfbQKoKAhv37GC" Ids="K2z8Q9r3OXhQI10Fqy92Ch,Cxfvc8ImF1SPuEJAW9yYnx" />
-          <Link Id="RI5x1HmudxoQcbhCCjgibp" Ids="CXwxKc8L2nbL60nfdgN6qZ,E21GwizdwKPPXGPY3Zj35l" IsHidden="true" />
-          <Link Id="DJADVFGGfa1MnvgBGywAuf" Ids="E21GwizdwKPPXGPY3Zj35l,V1kjB7X6YMEPxCHSyBwv7h" />
-          <ProcessDefinition Id="RX9DT6SEsO5LelBkRObo8C">
-            <Fragment Id="KKVK5XY73BgNK8Wa103eVM" Patch="IlIocJrU9WQMi4Z0SEYfh6" Enabled="true" />
-            <Fragment Id="GLclQTprcnLLPLADe5rNGE" Patch="LvoWMfA0PnXQNrCEKdYs5v" Enabled="true" />
-            <Fragment Id="HoXZHpGdaqjOMFRoQ57rsI" Patch="UQNkN8M2A3iLufBKiV2Uol" Enabled="true" />
-            <Fragment Id="JfSssT97x5gPY7ASj72awh" Patch="S9Z6hynhtl1P7fiR4U8rOj" Enabled="true" />
-            <Fragment Id="GuxwdSODE7iOcvdPEOqPNP" Patch="KcRjcGEBcP4MqzeesQHhiX" Enabled="true" />
-            <Fragment Id="RYfatcqBO0bMTFFNDjvTQq" Patch="Dv7ptkNn1fSQWPs9oZJiVi" Enabled="true" />
-            <Fragment Id="Ea1u3Nv3naOLTseOGHRecs" Patch="Keg6zengQ4HPRrXJY2GIye" Enabled="true" />
-            <Fragment Id="AnzUB60uZ6JNzWm8CxEQb5" Patch="U750NVT5ewgNxh5TYOL056" Enabled="true" />
-          </ProcessDefinition>
-          <Link Id="Q9pYXTNDjGyNFTYuG3isZg" Ids="BY77hhOsFxzPXMDyZMTgXv,S7jmVhvS9cELTFN4D3brY9" />
-          <Link Id="UZP1TO8MyfeP7arSTOUCEz" Ids="BZGAXjG1YDcOVHnU1MHxK6,BY77hhOsFxzPXMDyZMTgXv" IsHidden="true" />
-          <Link Id="P56mxbsprA8OGR8zWliSMk" Ids="NCRZDIwdYbLMRtcrCi0T5s,NFtVECDYpguLiQhC3gSYEg" />
-          <Link Id="LBqyuxPMjHfPFmdioBbtXu" Ids="NFtVECDYpguLiQhC3gSYEg,PSR1hpPloFELOcxhsw8SmX" IsHidden="true" />
-          <Patch Id="IlIocJrU9WQMi4Z0SEYfh6" Name="Create" />
-          <Patch Id="LvoWMfA0PnXQNrCEKdYs5v" Name="Update" ParticipatingElements="M5TeDHxTFLuNBA3XCl0F2i" ManuallySortedPins="true">
-            <Pin Id="H3Cr7UIBlvgLWWq0HYZXay" Name="Scene Instance" Kind="InputPin" Bounds="171,613" />
-            <Pin Id="HnaIu5sc1qHOyD8pOQ6vGU" Name="Camera" Kind="InputPin" Bounds="826,560" />
-            <Pin Id="HEOI7Gbq4lPQGKK88qY4xw" Name="Clear" Kind="InputPin" Bounds="355,581" />
-            <Pin Id="DnP3tPpt07pNxPwuSyOYao" Name="Clear Color" Kind="InputPin" Bounds="385,606" />
-            <Pin Id="PnhamUm3dI3ORORb6EEGM2" Name="Post Effects" Kind="InputPin" Bounds="864,478">
-              <p:TypeAnnotation LastCategoryFullName="Stride.API.Rendering.Images" LastDependency="VL.Stride.vl">
-                <Choice Kind="TypeFlag" Name="IPostProcessingEffects" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="TKyZy1DO0BSMoNfKTlcHsx" Name="Enable Default Post Effects" Kind="InputPin" Bounds="647,235" />
-            <Pin Id="UWL02voMskdQDB4nhrvoJ0" Name="Render Group Mask" Kind="InputPin" Bounds="617,633" />
-            <Pin Id="BE7nl5ySoKIPzRLKGSIBXE" Name="Edit Mode" Kind="InputPin" />
-            <Pin Id="I5Q4LWrlGjnLGAwEqTmabV" Name="Model Effect Name" Kind="InputPin" Bounds="870,554" />
-            <Pin Id="BZGAXjG1YDcOVHnU1MHxK6" Name="Additional Scene Renderers" Kind="InputPin" Bounds="803,629" />
-            <Pin Id="CZ7CDZVnvkcLuhJ8fsXrLR" Name="Output" Kind="OutputPin" Bounds="223,783" />
-            <Pin Id="PSR1hpPloFELOcxhsw8SmX" Name="Compositor" Kind="OutputPin" Bounds="452,750" />
-          </Patch>
-          <Patch Id="S9Z6hynhtl1P7fiR4U8rOj" Name="SetLightShafts">
-            <Pin Id="I40N3ISJ8ugLDYNUiGF3nF" MergeId="549640" Name="Light Shafts" Kind="InputPin" />
-          </Patch>
-          <Patch Id="KcRjcGEBcP4MqzeesQHhiX" Name="SetVRSettings">
-            <Pin Id="HbMHcxBKWHiN8AXNP4A41a" MergeId="551209" Name="VR Settings" Kind="InputPin" />
-          </Patch>
-          <Patch Id="Keg6zengQ4HPRrXJY2GIye" Name="SetSubsurfaceScatteringBlurEffect">
-            <Pin Id="MNBE9JXjJ4bPG1lo5HjDRi" Name="Subsurface Scattering Blur Settings" Kind="InputPin" />
-          </Patch>
-          <Patch Id="UQNkN8M2A3iLufBKiV2Uol" Name="SetMSAA">
-            <Pin Id="BucO8WUpMLuMBG6umnqdug" MergeId="554369" Name="MSAALevel" Kind="InputPin" DefaultValue="X4">
-              <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
-                <Choice Kind="TypeFlag" Name="MultisampleCount" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="DWoww3yGz7oMmNMqk9K7gr" MergeId="555947" Name="MSAAResolver" Kind="InputPin" />
-          </Patch>
-          <Patch Id="U750NVT5ewgNxh5TYOL056" Name="SetBindDepthDuringTransparentStage">
-            <Pin Id="TGozGkqUMfPOKgmYSd6s80" MergeId="557534" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" />
-          </Patch>
-          <Patch Id="Dv7ptkNn1fSQWPs9oZJiVi" Name="SetViewportSettings">
-            <Pin Id="CXwxKc8L2nbL60nfdgN6qZ" MergeId="484258" Name="Viewport Settings" Kind="InputPin" />
-          </Patch>
-        </Patch>
-      </Node>
-      <!--
-
-    ************************ GetShadowParameters ************************
-
--->
-      <Node Name="GetShadowParameters" Bounds="557,582" Id="Li7DVggvTn6N70tStBULwc">
-        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-          <Choice Kind="ContainerDefinition" Name="Process" />
-        </p:NodeReference>
-        <Patch Id="TqLDdvsiKW0OXo7BeblCuj">
-          <Canvas Id="GkSuIp0hesPL90qxOLRkoC" CanvasType="Group">
-            <ControlPoint Id="LpTEIVyc8PSOOyUyDZbkR4" Bounds="451,315" />
-            <Node Bounds="268,441,948,1274" Id="LQX6HO3yYIXPAVTyjSHTqz">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-                <Choice Kind="ApplicationStatefulRegion" Name="If" />
-              </p:NodeReference>
-              <Pin Id="QTeefJIWQ8WOff6JdiIVoi" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="PBkvV1Ci1NaMd1H3BMOYrd" Bounds="634,1709" Alignment="Bottom" />
-              <ControlPoint Id="TyAxVie1aNBPX9sxWq56Br" Bounds="630,447" Alignment="Top" />
-              <ControlPoint Id="MgtnR94gvIDNfeR16Onh02" Bounds="716,1709" Alignment="Bottom" />
-              <ControlPoint Id="CzCnaCBE2oOPLPCsKXuild" Bounds="712,447" Alignment="Top" />
-              <ControlPoint Id="RxrJGMuVJvINnbrwHniJ8Q" Bounds="812,1709" Alignment="Bottom" />
-              <ControlPoint Id="QoeEs2NCif2LSN3gnbNbx7" Bounds="792,447" Alignment="Top" />
-              <ControlPoint Id="KvrXdSJvZRmMMaWmJQsiEq" Bounds="463,1709" Alignment="Bottom" />
-              <ControlPoint Id="GwunZm8c14COYpmWUOg19w" Bounds="479,447" Alignment="Top" />
-              <ControlPoint Id="AHPikePdeKZLrtpyXYWuan" Bounds="941,1709" Alignment="Bottom" />
-              <ControlPoint Id="FepXhhqTxgaNmtGCczvGfd" Bounds="961,447" Alignment="Top" />
-              <ControlPoint Id="Jx9otizf3yWN1UsjqSXJwa" Bounds="1077,1709" Alignment="Bottom" />
-              <ControlPoint Id="QdBkaLHWgDqN9mtk31CZ6I" Bounds="1062,447" Alignment="Top" />
-              <ControlPoint Id="VHmTl8JaMx2PWpRKzEysKe" Bounds="1151,1709" Alignment="Bottom" />
-              <ControlPoint Id="OPb5cS9Df9RNmJtXH1x8TT" Bounds="1142,447" Alignment="Top" />
-              <Patch Id="UGMbXy2kDc3LAdhyEJQDY8" ManuallySortedPins="true">
-                <Patch Id="Fh6XcASr2dgQIdkQtcYsxd" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="Mm5KndLS6ZRMPflqEpk42r" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="445,464,89,26" Id="FanLiFKMPWfP83wq4yXwu7">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Compositing.GraphicsCompositor" LastDependency="Stride.Engine.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="GraphicsCompositor" />
-                    <Choice Kind="OperationCallFlag" Name="RenderSystem" />
-                  </p:NodeReference>
-                  <Pin Id="Od23u7jF2HVQN0nyxZe0qN" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="D9G6uRKqMSHPtTLpt1mMEH" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="GY3SbIXBBQ7P4j44eGNAIB" Name="Render System" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="438,514,87,26" Id="UvJldMi8NXFQbyAbWS1FdW">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.RenderSystem" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="RenderSystem" />
-                    <Choice Kind="OperationCallFlag" Name="RenderFeatures" />
-                  </p:NodeReference>
-                  <Pin Id="DVVjMListXjLdoMbMRBlZS" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Kr1d4JDvl4QLsC8IPEz0cq" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="GklHXgQodDWPTTjQhWlNc8" Name="Render Features" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="604,549,87,26" Id="F9TF53FfFMQQRQU0Wd4E7P">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshRenderFeature" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="MeshRenderFeature" />
-                    <Choice Kind="OperationCallFlag" Name="Create" />
-                  </p:NodeReference>
-                  <Pin Id="SMY1H1G3ricQVq8PON9Umj" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="478,604,80,19" Id="G5jSNbb7B8AP5W5CmDe9Gz">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
-                  </p:NodeReference>
-                  <Pin Id="E2IEHEPrsoPPxWMGdtMVgd" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="VZ7dFlmHtuuQStqOzGodNb" Name="Default Value" Kind="InputPin" />
-                  <Pin Id="QzamI9cyPKMP6aXs9fJTo8" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="FiGuRyBGyfiQdd41s7AXGE" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="492,648,87,26" Id="JwNecSWkABIOYg4RI1kzUc">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshRenderFeature" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="MeshRenderFeature" />
-                    <Choice Kind="OperationCallFlag" Name="RenderFeatures" />
-                  </p:NodeReference>
-                  <Pin Id="GuSvYAXS7D8OWn51WLyTJU" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Bm7PnK9IqUxP2Znd8LI7DL" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="Cn94VREA8g7MHprI9AQAiP" Name="Render Features" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="526,740,80,19" Id="Ay0q0vbjwcCOmcwrA1w2kj">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
-                  </p:NodeReference>
-                  <Pin Id="I5sr01GB4l3NSIGe5Hioia" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="GJjUx8Mhz1pLCYB10JvmNv" Name="Default Value" Kind="InputPin" />
-                  <Pin Id="HTuvTxn5zC4O3pn4O3tS8m" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="KQkopUKAvl6McnjMH186qn" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="616,691,126,26" Id="QfOnbvAmj38McSBoQCLHr4">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.ForwardLightingRenderFeature" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Create" />
-                  </p:NodeReference>
-                  <Pin Id="Ot2KRhSUscpNAaAXCt5lOG" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="537,701,49,19" Id="RfxPNxwJH09NiG4aLbnWHl">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="OfType" />
-                  </p:NodeReference>
-                  <Pin Id="K9AibQoXVq4M6AFZyQunLi" Name="Input" Kind="InputPin" />
-                  <Pin Id="MZEKGFCllDcLZWQV8nfph3" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="503,562,49,19" Id="HJjJNn7OJMUNgqe7wyVQct">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="OfType" />
-                  </p:NodeReference>
-                  <Pin Id="HjUvcyNZ0JEP9GaToS5DRd" Name="Input" Kind="InputPin" />
-                  <Pin Id="RwAAKON7h57O5QIH0dwhUy" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="566,786,126,26" Id="FagkAHKYK6WPPuFBZouB4a">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.ForwardLightingRenderFeature" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="ShadowMapRenderer" />
-                  </p:NodeReference>
-                  <Pin Id="JYwfCsV2dCwNXN1jwgsHMu" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Ufwtz4BpPdELFbyhzbBCK8" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="M4X9jHLl3nLQX8Rw8rN9mM" Name="Shadow Map Renderer" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="653,841,48,19" Id="O8iwGizClu2P4F98nrCfXX">
-                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="CastAs" />
-                  </p:NodeReference>
-                  <Pin Id="Ni7YWwjEzpBObVO4pgc6eX" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Hz0uZCk8HYDL5Hv1tP0XAh" Name="Default" Kind="InputPin" />
-                  <Pin Id="GUb7id7WQXPMWSWeIFmQNx" Name="Result" Kind="OutputPin" />
-                  <Pin Id="AG8yNNO6MvCNv5wXfmLW03" Name="Success" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="716,809,111,19" Id="IF6dIIzsUnyLVfaFGk3SnL">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadow" LastDependency="VL.Stride.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="Category" Name="Shadow" NeedsToBeDirectParent="true" />
-                    <Choice Kind="ProcessAppFlag" Name="ShadowMapRenderer" />
-                  </p:NodeReference>
-                  <Pin Id="E1Xosqbn2qTL8j6S8FDiN5" Name="Renderers" Kind="InputPin" />
-                  <Pin Id="JFU94OJtpsTNZLHOCCT7aE" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="654,874,91,19" Id="ONJ6HKA1c1uPdUgHDXyDlN">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="GetShadowMaps" />
-                  </p:NodeReference>
-                  <Pin Id="GMMNkNW2L37MqSuNkE0Ttv" Name="Feature" Kind="InputPin" />
-                  <Pin Id="SIreuv6T09PMlTCtgZ0rk8" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="487,869,80,19" Id="ArFMLrXe0TCNlLV2BQQBpR">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
-                  </p:NodeReference>
-                  <Pin Id="CFb6EFh5cNQPRQUN0sOOgS" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="TxxVwGrssfCMOI9pAkordj" Name="Default Value" Kind="InputPin" />
-                  <Pin Id="GGuuBRgmLhvLtYfA5mEBZZ" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="VocbaQGgwNDM0mNBAJs3LR" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="1051,858,50,26" Id="ACZkfz9WtlWMsasmAkdDyS">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightSpot" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="LightSpot" />
-                    <Choice Kind="OperationCallFlag" Name="Create" />
-                  </p:NodeReference>
-                  <Pin Id="RvdRYw30FxGPD71XjjKz9H" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="291,943,913,729" Id="Km3yAUiRdPUN5GHm66C9FT">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                    <CategoryReference Kind="Category" Name="Primitive" />
-                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                  </p:NodeReference>
-                  <Pin Id="BIIYXZKkQL8Py9T7xcs5Pl" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="CB2i1yqDgylMI4tedkJaEb" Bounds="472,1666" Alignment="Bottom" />
-                  <ControlPoint Id="CVTtgyMzH0xOegdSxz9xVi" Bounds="498,949" Alignment="Top" />
-                  <ControlPoint Id="MoI9UC9xTB9P2GZlokx5rn" Bounds="626,1666" Alignment="Bottom" />
-                  <ControlPoint Id="AZ4fNYJrDNhNj2jMn3Lwu4" Bounds="621,949" Alignment="Top" />
-                  <ControlPoint Id="D2nnCKB80CKLsxT61rREYd" Bounds="722,1666" Alignment="Bottom" />
-                  <ControlPoint Id="JS9Me0Fv7SvNY5xTlaIZSt" Bounds="717,949" Alignment="Top" />
-                  <ControlPoint Id="TBHc38wkDx2OUlCRR8tJ2L" Bounds="806,1666" Alignment="Bottom" />
-                  <ControlPoint Id="BgYAEM60fBRNox6voR9zOl" Bounds="778,949" Alignment="Top" />
-                  <ControlPoint Id="PWnUVwoHOa2OCFlkTqAAEX" Bounds="934,1666" Alignment="Bottom" />
-                  <ControlPoint Id="CFznCZh1LUBOgEp5chNn72" Bounds="963,949" Alignment="Top" />
-                  <ControlPoint Id="J5NTlPg637XLBh1QJXMzq1" Bounds="1076,1666" Alignment="Bottom" />
-                  <ControlPoint Id="LvYmSHhLUjgOvF0VswHoon" Bounds="1061,949" Alignment="Top" />
-                  <ControlPoint Id="GNR0pZZBPiqOkmHl1WFxHh" Bounds="1153,1666" Alignment="Bottom" />
-                  <ControlPoint Id="GttD9HPfpLhQdM9On9ZEvV" Bounds="1144,949" Alignment="Top" />
-                  <Patch Id="Q1iSl8r9DLPLFrdVFzEzbV" ManuallySortedPins="true">
-                    <Patch Id="GWEGixAYCGsNRuroiKZPgD" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="IElajHkdpm8Pb7ZN4maRl1" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="307,1254,104,26" Id="A7JKHG99XQqQLWCytDwSog">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
-                        <Choice Kind="OperationCallFlag" Name="Atlas" />
-                      </p:NodeReference>
-                      <Pin Id="IRC29P6JrknMvO6geFOm26" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="UKOt0IITzZELuRAs9dWoEp" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="J6CwHaeQSdhMyutzQYMgNL" Name="Atlas" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="303,1352,104,26" Id="QtmBDQHzfj9MrtqxVmHmJN">
-                      <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.ShadowMapAtlasTexture" LastDependency="Stride.Rendering.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="AssemblyCategory" Name="ShadowMapAtlasTexture" />
-                        <Choice Kind="OperationCallFlag" Name="Texture" />
-                      </p:NodeReference>
-                      <Pin Id="B3ey7TZuMXFO9hMlTJxCGk" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="UyBuwJ9gOJ4N2qkTGqcYZI" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="FQC2rkgu8CNPV19bw1GBFV" Name="Texture" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="655,1212,146,19" Id="CKyHABrhqv7QDFxwAwDEjR">
-                      <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="GetLightShadowShaderDatas" />
-                      </p:NodeReference>
-                      <Pin Id="KthM0PTFY0tPjU0WNdXbEU" Name="Shadows" Kind="InputPin" />
-                      <Pin Id="JAy7EBFwxFdN5NA6y5zNqR" Name="Directional" Kind="OutputPin" />
-                      <Pin Id="Mx7gFa6bS6wMNDFHskV2lt" Name="Spot" Kind="OutputPin" />
-                      <Pin Id="K91xK0N5x50PUHWsM7ezWK" Name="Point" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="914,963,278,246" Id="ONkN7XQuCmXQS8tH8DqOn1">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                        <CategoryReference Kind="Category" Name="Primitive" />
-                        <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                      </p:NodeReference>
-                      <Pin Id="KOMCsVGOnBXMXJsBwvMcP5" Name="Break" Kind="OutputPin" />
-                      <Patch Id="Fhw6AZRSXvwPIeqnYTt0Nt" ManuallySortedPins="true">
-                        <Patch Id="UKtqGiEQAV4MsQ8YZsoNkn" Name="Create" ManuallySortedPins="true" />
-                        <Patch Id="V15wJmkQ8tzNAs7uvIvoF6" Name="Update" ManuallySortedPins="true">
-                          <Pin Id="KlBVmL1NgRbPa690MkbVsN" Name="Keep" Kind="OutputPin" />
-                        </Patch>
-                        <Patch Id="NwGOY7rSt9MOUoKyOnnO3c" Name="Dispose" ManuallySortedPins="true" />
-                        <Node Bounds="926,1043,104,26" Id="D6Zz3jJCfWTLVPOj30RZha">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
-                            <Choice Kind="OperationCallFlag" Name="Light" />
-                          </p:NodeReference>
-                          <Pin Id="OHGZMXg2fkjOYYqDplYb1X" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="QHbvbWiwfsCM4Y1ASOYIYV" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="BP5eWaKNSe9LXNmm8T5gDA" Name="Light" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="931,996,104,26" Id="VYrBs8IQNMmOGi97tJzaAa">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="RenderLight" />
-                          </p:NodeReference>
-                          <Pin Id="QVYd0Np6o6BLcvIdTeRfO7" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="MwOZZG4nuunPGSyxZ7PWqj" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="C6EXwn8KpW5NUMT6f7yY5Z" Name="Render Light" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="1110,1045,59,26" Id="JBIoDhYXai9MbYhxbfzsyv">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
-                            <Choice Kind="OperationCallFlag" Name="Position" />
-                          </p:NodeReference>
-                          <Pin Id="Iam28afpcm9LISSIhKgMnD" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="Oqm6bWqbuoXL23NJuJqLe4" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="JZ7ybZ9LfoELB4s36WEQY2" Name="Position" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="1095,1099,59,26" Id="KQBmkv7XcwnOwZZLrcU7Gk">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
-                            <Choice Kind="OperationCallFlag" Name="Direction" />
-                          </p:NodeReference>
-                          <Pin Id="Jv6cyhJiSdYOKdMosA4HbW" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="OEYmbwKRCecLgcyhbYfFnW" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="KO2rKTod9dPMFFlkS7HA0K" Name="Direction" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="1010,1092,48,19" Id="NWz7X3wZ8oIM0g2Y9EhHiZ">
-                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="CastAs" />
-                          </p:NodeReference>
-                          <Pin Id="UzFQ8eKEQyzMRbTkBdb5bu" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="LvZPcvR14ejME75TxYWtXY" Name="Default" Kind="InputPin" />
-                          <Pin Id="VJBEnF9mT6vOGPLKiI1S9n" Name="Result" Kind="OutputPin" />
-                          <Pin Id="VDAzJqGAM2jLOviuNFkqY7" Name="Success" Kind="OutputPin" />
-                        </Node>
-                        <ControlPoint Id="VFUPSzK6AUDPjSix5iSnfD" Bounds="1059,1137" />
-                        <Node Bounds="945,1152,103,19" Id="LnWOhbNqJTuQNxlZiSbWuI">
-                          <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSpotLightParam" />
-                          </p:NodeReference>
-                          <Pin Id="IeB4Fxo3AmqPa5TV0grqOn" Name="Spot" Kind="InputPin" />
-                          <Pin Id="DewzWILu0JFMcCPbRY0W4z" Name="Result" Kind="OutputPin" />
-                        </Node>
-                      </Patch>
-                      <ControlPoint Id="AceN2CnlaDYN2j8KZoWvHS" Bounds="928,969" Alignment="Top" />
-                      <ControlPoint Id="Ubxe9G8SbRTLZGvn5IBbdU" Bounds="1175,1203" Alignment="Bottom" />
-                      <ControlPoint Id="G4JSiL0mBEdMw7lRpLcXdS" Bounds="1137,1203" Alignment="Bottom" />
-                      <ControlPoint Id="Ej94gf8M191O2wUQr96uLF" Bounds="995,1203" Alignment="Bottom" />
-                    </Node>
-                    <Node Bounds="892,1245,233,358" Id="VS5zpz9O9roNLvo89FOurp">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                        <CategoryReference Kind="Category" Name="Primitive" />
-                        <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                      </p:NodeReference>
-                      <Pin Id="IhcickhR8mjNK6Kk61NpfH" Name="Break" Kind="OutputPin" />
-                      <Patch Id="F7Fox1qHSYlPqVFUS1owkI" ManuallySortedPins="true">
-                        <Patch Id="DVMN9M5KVrLNEcuYdOqne7" Name="Create" ManuallySortedPins="true" />
-                        <Patch Id="TrEDlHRaY49LgKehgPjVxW" Name="Update" ManuallySortedPins="true">
-                          <Pin Id="QZJsfMwJIJBMxzww4ws9B7" Name="Keep" Kind="OutputPin" />
-                        </Patch>
-                        <Patch Id="LGjXnIS4GjWMndBwGAGkAP" Name="Dispose" ManuallySortedPins="true" />
-                        <Node Bounds="904,1328,104,26" Id="B8QkyflnUiHLrS3RlVfy8d">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
-                            <Choice Kind="OperationCallFlag" Name="Light" />
-                          </p:NodeReference>
-                          <Pin Id="FjAJ2JmMsThLGxiBaHqBGW" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="H36MwZzuAbaNmGlXYjTF9v" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="PcAqkJW75g9M0Y1m1qEXUn" Name="Light" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="904,1280,104,26" Id="Rrfo3TT35S3OupP3GMS7TJ">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="RenderLight" />
-                          </p:NodeReference>
-                          <Pin Id="LvSgXNqnIrzPTz3HtITmIu" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="IulOUYBeSkoL2rwqgAtjmI" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="SUBczsByi1oO3q1qZabsbV" Name="Render Light" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="1046,1481,59,26" Id="AGIYo2kcmZDOHZWCuKrOI6">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
-                            <Choice Kind="OperationCallFlag" Name="Position" />
-                          </p:NodeReference>
-                          <Pin Id="Tu8maN4RSRKNVGPtjMf1gm" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="HOMsr1J7DWKOgKpBQ3aQxr" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="KovtxbJRE45Oq3bzD99MHh" Name="Position" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="952,1377,48,19" Id="Kb4Y6LuGtLbPvxmYHdGuMt">
-                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="CastAs" />
-                          </p:NodeReference>
-                          <Pin Id="TsvQnCAkwZhMsr6XR97Nyu" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="IQwGMdYZRDrMChaVfnMwvY" Name="Default" Kind="InputPin" />
-                          <Pin Id="SgJlEm3UXzHPc1iNiHPQIe" Name="Result" Kind="OutputPin" />
-                          <Pin Id="HnKWqtfeTMtOiol7FZiPAE" Name="Success" Kind="OutputPin" />
-                        </Node>
-                        <ControlPoint Id="LvPQmQYT9URMFSAHKjW6Xf" Bounds="1035,1413" />
-                        <Node Bounds="957,1564,46,19" Id="CVRCPPKQeX6LO1nUHJDAvj">
-                          <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
-                            <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
-                          </p:NodeReference>
-                          <Pin Id="VWZ7EwP2z0mMHrRkwHthWz" Name="X" Kind="InputPin" />
-                          <Pin Id="KrYRR9MOt6ZNlV3JKKU0Mr" Name="Y" Kind="InputPin" />
-                          <Pin Id="AN7UWR8TIKsPhdO0ePKB4D" Name="Z" Kind="InputPin" />
-                          <Pin Id="VAVFRSx44S9MyjZ3nGrBv4" Name="Output" Kind="StateOutputPin" />
-                        </Node>
-                        <Node Bounds="928,1422,92,126" Id="FGJMXxp47xSLdczmWtSGQR">
-                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                            <CategoryReference Kind="Category" Name="Primitive" />
-                            <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                          </p:NodeReference>
-                          <Pin Id="SgQaN45NbzfLXVHVityhbr" Name="Condition" Kind="InputPin" />
-                          <Patch Id="RnxafnHvfk2MgBvcqjoznC" ManuallySortedPins="true">
-                            <Patch Id="TVpXtr6FQEzQOYZVahfZmt" Name="Create" ManuallySortedPins="true" />
-                            <Patch Id="UJ0GB40p9tvNMNialgWYGl" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="940,1445,52,26" Id="DVB4Sf6kU9QO2YTt21wByE">
-                              <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightPoint" LastDependency="Stride.Rendering.dll">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <CategoryReference Kind="AssemblyCategory" Name="LightPoint" />
-                                <Choice Kind="OperationCallFlag" Name="Radius" />
-                              </p:NodeReference>
-                              <Pin Id="QeHf8DR43g1L5S6aHa9cdI" Name="Input" Kind="StateInputPin" />
-                              <Pin Id="FQVHAQvv9y9Ofe047ngRpe" Name="Output" Kind="StateOutputPin" />
-                              <Pin Id="Rn6jziApTJQOOFXuHv2SIu" Name="Radius" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="983,1482,25,19" Id="DNVbrdLaiVpM1uF5v57f37">
-                              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="*" />
-                              </p:NodeReference>
-                              <Pin Id="U7T4movu5BiPFkPUd825J5" Name="Input" Kind="InputPin" />
-                              <Pin Id="HItTMNhmrLyLvChizwcxmg" Name="Input 2" Kind="InputPin" />
-                              <Pin Id="JgdTNYXZXjGO9vR8fb8c5C" Name="Output" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="968,1509,25,19" Id="VwBGfsnPrivOZpx7AK6jiI">
-                              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="/" />
-                              </p:NodeReference>
-                              <Pin Id="Ez2nfjd6OE6NBCpmI89ocu" Name="Input" Kind="InputPin" DefaultValue="1" />
-                              <Pin Id="GDYdWmGHB5NP9OTc6rysH5" Name="Input 2" Kind="InputPin" />
-                              <Pin Id="TxM5Lviu1FtM422IYhI8Bh" Name="Output" Kind="OutputPin" />
-                            </Node>
-                          </Patch>
-                          <ControlPoint Id="BZNDC6hA1XVQamgaxXauDC" Bounds="970,1542" Alignment="Bottom" />
-                          <ControlPoint Id="DAOJ29fH3JoN2q54759rxi" Bounds="970,1428" Alignment="Top" />
-                        </Node>
-                      </Patch>
-                      <ControlPoint Id="MwsiUN4bcwrLbpPSMWRtPQ" Bounds="909,1251" Alignment="Top" />
-                      <ControlPoint Id="URMu8GqeetBNwWs5ghbCzY" Bounds="1108,1597" Alignment="Bottom" />
-                      <ControlPoint Id="HXWKQ1ApJpcPh8C7YkosB2" Bounds="951,1597" Alignment="Bottom" />
-                    </Node>
-                    <Node Bounds="1061,1623,63,26" Id="KhxeAZ8mmNWQRes4eKynkE">
-                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                        <Choice Kind="OperationCallFlag" Name="AddRange" />
-                      </p:NodeReference>
-                      <Pin Id="PJrxwtf3EAmLblvatyIzfq" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="NPfmZZKXTUdMrbITA8FnpE" Name="Items" Kind="InputPin" />
-                      <Pin Id="UoWfzErKp3tQOTonCPyYRy" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                    <Node Bounds="875,1618,63,26" Id="IlMoTPl6pd5MqSHYIl6DWN">
-                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                        <Choice Kind="OperationCallFlag" Name="AddRange" />
-                      </p:NodeReference>
-                      <Pin Id="FJSkquNGvVZLo6Sdf2uy53" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="QxPOJbdIql6LxBqVpz5jKy" Name="Items" Kind="InputPin" />
-                      <Pin Id="GhPEGN5anMgPsZx8uWLlYw" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                    <Node Bounds="477,1065,206,453" Id="UmpZxTV22vHMYghsfabAru">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                        <CategoryReference Kind="Category" Name="Primitive" />
-                        <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                      </p:NodeReference>
-                      <Pin Id="FYa0yIQL07GOJqHVVURGFU" Name="Break" Kind="OutputPin" />
-                      <ControlPoint Id="FUepA0oSPVGNsc4fvNqJJO" Bounds="491,1071" Alignment="Top" />
-                      <Patch Id="NDjdTHgRroSOOfGSYFfXaB" ManuallySortedPins="true">
-                        <Patch Id="BW5P5UnmOOnMQN8h7TwJLY" Name="Create" ManuallySortedPins="true" />
-                        <Patch Id="EqUyeRVEVmsQXFF2CtR2U5" Name="Update" ManuallySortedPins="true" />
-                        <Patch Id="DJ6WRX0fddsNCPWS55eow0" Name="Dispose" ManuallySortedPins="true" />
-                        <Node Bounds="489,1092,104,26" Id="BoEisRuxIDxN0LXiSxkfaQ">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
-                            <Choice Kind="OperationCallFlag" Name="FilterType" />
-                          </p:NodeReference>
-                          <Pin Id="Fj2e38W72wKMZjJb5Vwhmm" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="CTxGS1hPxtfLFI60FpHNhZ" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="JeUF3cIp1GLPQmGCCE4WPs" Name="Filter Type" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="490,1143,104,26" Id="TTW38fcrEZlLjcsd16jPi9">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
-                            <Choice Kind="OperationCallFlag" Name="Shadow" />
-                          </p:NodeReference>
-                          <Pin Id="N4OqZEW77Y9NKLoCSpu5Im" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="MyLh2OKzkiwODgQsrvLROX" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="KP7f80TVAsbOFDrJWeiQFD" Name="Shadow" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="503,1206,77,26" Id="PXvGJYQu7jWOSW4EmZph0w">
-                          <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightShadowMap" LastDependency="Stride.Rendering.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="LightShadowMap" />
-                            <Choice Kind="OperationCallFlag" Name="Filter" />
-                          </p:NodeReference>
-                          <Pin Id="FagqfN8fFmdOZLmYSs5THL" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="DaSMOzeRZmyLrorqR3pq7w" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="J6nQ4omJ1vANtzQQUJXyat" Name="Filter" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="499,1280,48,19" Id="F4fWAC4idfnQEtDVpt06I6">
-                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="CastAs" />
-                          </p:NodeReference>
-                          <Pin Id="RASXhdcMGPHL6scM5yWI5n" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="FsfqV87z732NE1j9LKLAFO" Name="Default" Kind="InputPin" />
-                          <Pin Id="Grxcdfa0TwCLQ9qnqXsIFS" Name="Result" Kind="OutputPin" />
-                          <Pin Id="UKpn9z528hULJnWLUjJotB" Name="Success" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="525,1328,146,166" Id="DILmqWMjs2hMX0e4H2sPR0">
-                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                            <CategoryReference Kind="Category" Name="Primitive" />
-                            <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                          </p:NodeReference>
-                          <Pin Id="Rwf9imM2P4zMkAW6Pel8Fq" Name="Condition" Kind="InputPin" />
-                          <Patch Id="QpimTg4Er75Lr6fgpn30tk" ManuallySortedPins="true">
-                            <Patch Id="I0tDeaV5JPzPCgEJUh3d3q" Name="Create" ManuallySortedPins="true" />
-                            <Patch Id="JTtPrUAV1eZLDsov21dMDN" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="537,1351,122,26" Id="HqryP2iIhYPL9KUrI6w4rz">
-                              <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightShadowMapFilterTypePcf" LastDependency="Stride.Rendering.dll">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapFilterTypePcf" />
-                                <Choice Kind="OperationCallFlag" Name="FilterSize" />
-                              </p:NodeReference>
-                              <Pin Id="N6RPCh6SujiOjO5NUB55LN" Name="Input" Kind="StateInputPin" />
-                              <Pin Id="RzZFBfwj50FNF3GvnEQt0W" Name="Output" Kind="StateOutputPin" />
-                              <Pin Id="UIRYe3mMPm0PidPwXjMTSf" Name="Filter Size" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="550,1387,65,19" Id="JU1H6ovnn5jLfTNvuPY1wv">
-                              <p:NodeReference LastCategoryFullName="Primitive.Enum" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="Enum2Ord" />
-                              </p:NodeReference>
-                              <Pin Id="L7Z0OpGDK3tPzWwuIVVmlX" Name="Input" Kind="StateInputPin" />
-                              <Pin Id="QSWG6a3UTYbO8q4DZzIDxu" Name="Result" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="562,1455,25,19" Id="BmM5F0PjXDZOZSxkwBHAiq">
-                              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="+" />
-                              </p:NodeReference>
-                              <Pin Id="KuMN7NTLRS2QOBrWM2c7DC" Name="Input" Kind="InputPin" />
-                              <Pin Id="GTOQi69RZFfPzGYULW4wqc" Name="Input 2" Kind="InputPin" />
-                              <Pin Id="RcJLuKSlixtNCgXBLuqWtf" Name="Output" Kind="OutputPin" />
-                            </Node>
-                            <Pad Id="U8dshL1Ioj7PUI9WEHzCsj" Comment="" Bounds="596,1436,35,15" ShowValueBox="true" isIOBox="true" Value="3">
-                              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
-                                <CategoryReference Kind="Category" Name="Primitive" />
-                              </p:TypeAnnotation>
-                            </Pad>
-                            <Node Bounds="546,1421,25,19" Id="CpQKLaOiGs2PxGsppQjLyD">
-                              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="*" />
-                              </p:NodeReference>
-                              <Pin Id="Io1yhlmk5KSMHEGIkafGYT" Name="Input" Kind="InputPin" />
-                              <Pin Id="KJD5CP9UY8UQPkEZuZlUWe" Name="Input 2" Kind="InputPin" DefaultValue="2" />
-                              <Pin Id="SYneiBMaXv7Mf8WptsLcwR" Name="Output" Kind="OutputPin" />
-                            </Node>
-                          </Patch>
-                          <ControlPoint Id="Roi62KJglQDNSod2pYFcFW" Bounds="552,1488" Alignment="Bottom" />
-                          <ControlPoint Id="OKRIM6pUMJ7Pd9roAJ1q9p" Bounds="583,1334" Alignment="Top" />
-                        </Node>
-                        <Pad Id="KffoUwPCvbfPgq5bwzkGys" Comment="" Bounds="579,1299,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="TypeFlag" Name="Integer32" />
-                          </p:TypeAnnotation>
-                        </Pad>
-                      </Patch>
-                      <ControlPoint Id="AL4a9CXuwCLOeKqQdzAZzF" Bounds="548,1512" Alignment="Bottom" />
-                    </Node>
-                  </Patch>
-                  <ControlPoint Id="CsFuUxACG3SPoOlOdrSLxS" Bounds="538,1666" Alignment="Bottom" />
-                  <ControlPoint Id="SSTmV5Wlj3TOtZnlEzd1dc" Bounds="538,949" Alignment="Top" />
-                </Node>
-                <Node Bounds="456,909,65,19" Id="Q9JnjjocTKPO41dLFYykEQ">
-                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-                  </p:NodeReference>
-                  <Pin Id="GqaVrkb1KeOM4HQmbXywRw" Name="X" Kind="InputPin" />
-                  <Pin Id="Rx6sUAIWPFFQSxbo10Higl" Name="Result" Kind="OutputPin" />
-                  <Pin Id="UGqKYjDqL8ZLPiEvvBbGjE" Name="Not Assigned" Kind="OutputPin" />
-                </Node>
-              </Patch>
-              <ControlPoint Id="ECzSZeYQrhlQRpZEzRgZ44" Bounds="537,1709" Alignment="Bottom" />
-              <ControlPoint Id="QJgkmTaU9VZOG5yot78eeB" Bounds="537,447" Alignment="Top" />
-            </Node>
-            <Node Bounds="418,372,65,19" Id="PC10SJp96aRPFQKGO7BF3Q">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="IsAssigned" />
-              </p:NodeReference>
-              <Pin Id="BbokHxueVN4OmkxaN5pjvx" Name="X" Kind="InputPin" />
-              <Pin Id="M5A86MMZYg2NEyZp09pNva" Name="Result" Kind="OutputPin" />
-              <Pin Id="MO6fSXaxZwTMoo5KSFABTv" Name="Not Assigned" Kind="OutputPin" />
-            </Node>
-            <Pad Id="Jtx4uK1IGYIOoFJUp9nve7" Comment="Texture" Bounds="-111,2118,190,132" ShowValueBox="true" isIOBox="true" />
-            <Node Bounds="276,2230,345,271" Id="KyuRsNceAXNOkudFcB7GCH">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-              </p:NodeReference>
-              <Pin Id="MDQUhdRlbJhPpljV3FZBfb" Name="Break" Kind="OutputPin" />
-              <Patch Id="UvqHUNBiHiSNj7LCuv0c2e" ManuallySortedPins="true">
-                <Patch Id="PVgejApHUkmOMHG9Hl65EH" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="PJAb0CJ3XYBOxGqlxDTvqI" Name="Update" ManuallySortedPins="true" />
-                <Patch Id="THk9t2QEBzGO7Jf0qt0VdU" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="388,2319,168,26" Id="CjGz2EzLYGXPgJteZjjesG">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="DepthBias" />
-                  </p:NodeReference>
-                  <Pin Id="SrxqFV3xEoAPAnAXoFmi72" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="LRUeRw3YZk3Px0UFx1Ek9m" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="H66YlqQxLbgQVGK4ZcNSwk" Name="Depth Bias" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="288,2378,168,26" Id="TnGSnv2c81oOa0JVWiJ0rZ">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="WorldToShadowCascadeUV" />
-                  </p:NodeReference>
-                  <Pin Id="IwC0eUs243CNS4kRvfv3qg" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="LVudKmhwEafO9ybHYUlqOL" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="E3XInlp16igLaCXpulwUkx" Name="World To Shadow Cascade UV" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="441,2265,168,26" Id="Ldo6twDorzMMsvDQyZSQFU">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="OffsetScale" />
-                  </p:NodeReference>
-                  <Pin Id="GYc01OWlGGEOLic4ZPoGQA" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="LjDRNtL4rvwOd7uv0or3H1" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="S5hzSD8jQ0oN01Gx2FF3fT" Name="Offset Scale" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="340,2430,41,26" Id="UVieM33XpslM6uXDZZcXTo">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="S0bKqqYlbNaPOSX1f1btSz" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="LbES1dldW5hQdVFm66Scx5" Name="Item" Kind="InputPin" />
-                  <Pin Id="O1uak8tu1CXNXDfUBVsiKs" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="480,2407,41,26" Id="GXFAtXX8JhvP8nuSA5MEsx">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="RhcudGaiTUOPxkDa864Ox1" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="TbXlbSlhK04PIUyACFOYgX" Name="Item" Kind="InputPin" />
-                  <Pin Id="P1EmDzjyRAENbZU3aODZm7" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="551,2384,41,26" Id="LSi05zwZYPxPMSk9VaJkoH">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="BjlIau8qyiZQPSd8sferIK" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="DNNOevvgPWhLZ3Q06KSfEM" Name="Item" Kind="InputPin" />
-                  <Pin Id="L9WloKx3mU7PMOff5OrdUg" Name="Output" Kind="StateOutputPin" />
-                </Node>
-              </Patch>
-              <ControlPoint Id="SeGEWP1HjQlOBy1zYU1owo" Bounds="431,2236" Alignment="Top" />
-              <ControlPoint Id="HXqoVKww7koMvQFSHO15Jk" Bounds="349,2236" Alignment="Top" />
-              <ControlPoint Id="I0LxWcs8GHfPuG1iOo3c4f" Bounds="341,2495" Alignment="Bottom" />
-              <ControlPoint Id="MpQ6rSnIRmlOpKQpIGgler" Bounds="470,2495" Alignment="Bottom" />
-              <ControlPoint Id="SvjvBxB1h8xQMoaWI3o1dc" Bounds="470,2236" Alignment="Top" />
-              <ControlPoint Id="GYl3bq4XadWLx4xVW2LTOS" Bounds="557,2236" Alignment="Top" />
-              <ControlPoint Id="L9DN9MfFxSaP3v6KqwHOUh" Bounds="597,2495" Alignment="Bottom" />
-            </Node>
-            <Node Bounds="719,1756,57,26" Id="AVQJmAI1c5uPe3qFLTOmc6">
-              <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Count" />
-              </p:NodeReference>
-              <Pin Id="SNH2eUs1mKkMGg3aWrmPsa" Name="Input" Kind="StateInputPin" />
-              <Pin Id="CxV6GLXBD0VN2gDakC1t1l" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="RUDDJDxN6V6L79SYMzO4AI" Name="Count" Kind="OutputPin" />
-            </Node>
-            <Pad Id="Cm4CcKYY89WLdKiIeh7Ko7" Comment="Spot Light Count" Bounds="681,3154,35,15" ShowValueBox="true" isIOBox="true" Value="2">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="263,1887,321,278" Id="UcRPOrKCfGvNVaKqaHCARJ">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-              </p:NodeReference>
-              <Pin Id="Ehi26knCzU8Pq8VXc2jQfD" Name="Break" Kind="OutputPin" />
-              <Patch Id="UMYBA0Gok0FLvFbl3z5VBr" ManuallySortedPins="true">
-                <Patch Id="CjVrLX87gGQMBa2hAd0Voi" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="Jff7AlvSnOJPVAfnk8moSn" Name="Update" ManuallySortedPins="true" />
-                <Patch Id="PzyA6HF03VKOk0IkNOutEx" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="422,1959,62,26" Id="IzLSzvLKrNwOfOa4Ptx3tW">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="DepthBias" />
-                  </p:NodeReference>
-                  <Pin Id="QRzov8J4o0AMhOijvydlz6" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Kbt2Q8t4cqfN5AkxBfstRn" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="CDXsDhmgjf4PQMYdAtZw6z" Name="Depth Bias" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="320,2007,139,26" Id="P0d1q7IU6tANndWoSj63jI">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="WorldToShadowCascadeUV" />
-                  </p:NodeReference>
-                  <Pin Id="HrWO5lH8ApmLIez808Mze3" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="BqIkiLYKOHSNrUeXUVCbDL" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="LLbzBacZCTuOUAveYN9qhJ" Name="World To Shadow Cascade UV" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="473,1910,67,26" Id="SnPkM5HZkhsOcB399Agcyo">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="OffsetScale" />
-                  </p:NodeReference>
-                  <Pin Id="Q6f4Aj5SQJ2LagU8jdz6CI" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="H7R5ETG7l1wLgWtD3MvCjB" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="Nw0BZ0FaayEO8VYHyaF9kI" Name="Offset Scale" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="386,2066,63,26" Id="Ou9iiidqdMlQb4842dRHWJ">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="AddRange" />
-                  </p:NodeReference>
-                  <Pin Id="F5PMc8w1WMtQPEfe7zAWIg" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="A8MPHbwc8aQQTgqyETnQaZ" Name="Items" Kind="InputPin" />
-                  <Pin Id="ArhjJqTfsHuLbTtmRK1NvX" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="305,2102,63,26" Id="Gg7Ih6fGxshNno5uaDNJth">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="AddRange" />
-                  </p:NodeReference>
-                  <Pin Id="GBQIsQjgsOJOtuU45TZvYg" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="CbbA8LYJ0XJN2mtcR5shBv" Name="Items" Kind="InputPin" />
-                  <Pin Id="NgnSCaZIJGaQdVEWYagaeE" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="474,2045,41,26" Id="AArb1ZHDwjUNw0ic2A77Io">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="UEEKvXHOnLkQFoTyuzzHDK" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="OGREKlR63V6NYsNNhIXYkv" Name="Item" Kind="InputPin" />
-                  <Pin Id="D9yFiBfrA9KPtmuaYuy5af" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="531,1997,41,26" Id="PIikUpwHDfXNZoqBoSAW5e">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="SRyw21e6tbgLWcvndmEGC0" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="HUlG8C5GY41NZQYXnrwq7z" Name="Item" Kind="InputPin" />
-                  <Pin Id="EFMG0uG8BreQJydJZNgNYM" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="275,2057,78,26" Id="AasU2Fva2J6N52upo4Wakp">
-                  <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="CascadeSplits" />
-                  </p:NodeReference>
-                  <Pin Id="IxTkhy30MywO0EYmy3Ys1g" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="FuTPlSOw73nPCtI2DQWxQz" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="EU3346LPwhVO8tvs0R2zSi" Name="Cascade Splits" Kind="OutputPin" />
-                </Node>
-              </Patch>
-              <ControlPoint Id="PYzbslezMMLN4RcIr74Qyb" Bounds="479,1893" Alignment="Top" />
-              <ControlPoint Id="EDMnpMThjeJN7g5CxQ3Ggg" Bounds="390,2159" Alignment="Bottom" />
-              <ControlPoint Id="Ri880ax0sFtPGxKKTDd1wH" Bounds="395,1893" Alignment="Top" />
-              <ControlPoint Id="O7cGMveuU3YN08BlRso52h" Bounds="310,1893" Alignment="Top" />
-              <ControlPoint Id="LPxiUAMuca1OqCKvPjITq4" Bounds="313,2159" Alignment="Bottom" />
-              <ControlPoint Id="T63nxKhTj4tO5d32sTyhOt" Bounds="521,1893" Alignment="Top" />
-              <ControlPoint Id="Aw8u4UC7rcILR3oVvmHnp5" Bounds="468,2159" Alignment="Bottom" />
-              <ControlPoint Id="NJ5RhHpw7SSOZDfk7AU3lW" Bounds="551,1893" Alignment="Top" />
-              <ControlPoint Id="Viphair5txPOxUrWgaagoK" Bounds="527,2159" Alignment="Bottom" />
-            </Node>
-            <Node Bounds="616,1744,57,26" Id="VvJPNuFRXIuOvyiCcOGH8V">
-              <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Count" />
-              </p:NodeReference>
-              <Pin Id="S6zXamZDMJwOa69woIV1vG" Name="Input" Kind="StateInputPin" />
-              <Pin Id="LSBa99CEHvlQRyP1kvh4s6" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="H0jqxS1pg0jM7NB6kqC3GE" Name="Count" Kind="OutputPin" />
-            </Node>
-            <Pad Id="SFfROyM0VMlQFBgJUxTABZ" Comment="Directional Count" Bounds="623,3115,35,15" ShowValueBox="true" isIOBox="true" Value="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="573,3255,87,26" Id="OLW7oXYcfW4LScIvCeScAW">
-              <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="RecordType" Name="ShadowCatcherData" />
-                <Choice Kind="OperationCallFlag" Name="Create" />
-              </p:NodeReference>
-              <Pin Id="Fv4TZILVb6GPGrZNlr5izW" Name="ShadowMap" Kind="InputPin" />
-              <Pin Id="HGGWeKCI4eGLgkSOD5wqYC" Name="Buffers" Kind="InputPin" />
-              <Pin Id="TygSsmZBxb3PhaLHSh0kZM" Name="Directional Light Count" Kind="InputPin" />
-              <Pin Id="KezWVByE0ebPQa1Zkn44Zg" Name="Spot Light Count" Kind="InputPin" />
-              <Pin Id="TbtnfD4ljnMNxNJjL8mvaY" Name="Point Light Count" Kind="InputPin" />
-              <Pin Id="FAYkVzmOv4rQNGxCJT5bZ8" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="473,2961,165,19" Id="LKgr2VdzayzOkQVr8UnJUT">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Cons" />
-              </p:NodeReference>
-              <Pin Id="OT3kLfvjy9INL67VWN9lf0" Name="Input" Kind="InputPin" />
-              <Pin Id="PWUuucfPBcIPV4TG2BCSFt" Name="Input 2" Kind="InputPin" />
-              <Pin Id="UNDrqgFE5uKLty5LFby4cs" Name="Result" Kind="OutputPin" />
-              <Pin Id="QASwuwTCuo4PyQy6UKy6x6" Name="Input 3" Kind="InputPin" />
-              <Pin Id="OUytWbHYzEuO3y21bPbHab" Name="Input 4" Kind="InputPin" />
-              <Pin Id="RKesi8dX5BNN1xgA2LXWkX" Name="Input 5" Kind="InputPin" />
-              <Pin Id="O3GCnhSjKewNZfzHQI4Fhq" Name="Input 6" Kind="InputPin" />
-              <Pin Id="EHr8tGygaNfLlZJYlOtwMX" Name="Input 7" Kind="InputPin" />
-              <Pin Id="KpeZim2Cz9tLxjKzwSnWLF" Name="Input 8" Kind="InputPin" />
-              <Pin Id="QezHx76pAroPierYo5SVD5" Name="Input 9" Kind="InputPin" />
-            </Node>
-            <Node Bounds="824,1801,57,26" Id="NRwVbIGzy3rOtvqYvfRGMN">
-              <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Count" />
-              </p:NodeReference>
-              <Pin Id="TvrgwTwRsKTO1Je6s8RdnJ" Name="Input" Kind="StateInputPin" />
-              <Pin Id="I4ny1mKiZkdLwRxBoehOFA" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="SKbiApyNJrbLYqmNkkmyjY" Name="Count" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="NsleN6vwG0oP7NKv6NchvC" Bounds="574,3323" />
-            <Node Bounds="1040,2873,85,19" Id="UciQTM2R8uiNG4lmTHgWON">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="MyMImd1X7gnNiYPm34ta9h" Name="Input" Kind="InputPin" />
-              <Pin Id="C1TdkaJQOgENoVBaEuWymU" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="AHQQAiHkCybMrnKH7J7Xpn" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="NXeecvOTFHVNPWkCScxtdC" Name="Recreate" Kind="InputPin" />
-              <Pin Id="AUYERqidFIJLuTKH2cXLBf" Name="Apply" Kind="InputPin" />
-              <Pin Id="OYCVWYSgYb8N6AVgB0Z5JZ" Name="Output" Kind="OutputPin" />
-              <Pin Id="Cv6I8lmQ6IwPzUcyd6MDy0" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="509,2857,85,19" Id="GcEUJzzvWuxOCVWXFdPtwQ">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="SdQ0WZMq975PXnu3q9gagT" Name="Input" Kind="InputPin" />
-              <Pin Id="KgDQ7A7IQPvLdnUwU1TMPu" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="Q51mHfTr4oAP2SM1uYcQWQ" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="Dz5iC7K1j4VQP2iKIBA3Q3" Name="Recreate" Kind="InputPin" />
-              <Pin Id="TTYJPNZVETZNOIALmg7oiz" Name="Apply" Kind="InputPin" />
-              <Pin Id="MTCJjv4PM8rN33E12KXwHu" Name="Output" Kind="OutputPin" />
-              <Pin Id="SLJqQQhcmWqPmrBnwXgtTW" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="405,2858,85,19" Id="KEoJpjM5izMM6ehzxfRGo9">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="SLyShMNqyZuMN24bXu464M" Name="Input" Kind="InputPin" />
-              <Pin Id="QBDf1KDn8krOB3Whrj6kpC" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="LQxNhSUz2yrL5mdzPN1zlT" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="A7tD1X998roOIpGUFWBnQg" Name="Recreate" Kind="InputPin" />
-              <Pin Id="Ovwt67b8P4NLcUEpGTsmAa" Name="Apply" Kind="InputPin" />
-              <Pin Id="HcSN8kkQs5EOISMCcCfzYs" Name="Output" Kind="OutputPin" />
-              <Pin Id="JchvrV5rZQoL4dvPwi8abl" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="609,2858,85,19" Id="S5hlbmRpa8PNAY0YBhH2Id">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="QJC24pEeExwPdOblgD1JFE" Name="Input" Kind="InputPin" />
-              <Pin Id="If1dNgoMbc5Mw3ODFAJVZZ" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="U2M8R1JQrtCQKqqDq17lZI" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="SDVK5VNvswCQCZMjKueyZK" Name="Recreate" Kind="InputPin" />
-              <Pin Id="QPLKuuNYXAgMcpgiyyBnVf" Name="Apply" Kind="InputPin" />
-              <Pin Id="KpL44DuWybqPwKJ40vhGJX" Name="Output" Kind="OutputPin" />
-              <Pin Id="UJIGPQflCwfLtNXjUhuLx2" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="830,2858,85,19" Id="Reiru26q49TLJ0AqP5SlnW">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="DzKZQCxakA5OgnEMjNJwgi" Name="Input" Kind="InputPin" />
-              <Pin Id="QqpwXC9y1j2NdFKLal0rCg" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="PN6x1VnbbdfOm6H3FAt2D7" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="MCZhN9I8oguLq0rLQXsb24" Name="Recreate" Kind="InputPin" />
-              <Pin Id="AWkGOp7ZcW9L6n5CnWAviL" Name="Apply" Kind="InputPin" />
-              <Pin Id="F4pMHQgqZB5MKY9R8CUjsw" Name="Output" Kind="OutputPin" />
-              <Pin Id="SCpaC3z8FqZP5ZwaoBy2pp" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="715,2853,85,19" Id="LYYHhP3ryrjMSB4TFMWAwQ">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="L7Ojq1AxwbkP7t6a05kD0N" Name="Input" Kind="InputPin" />
-              <Pin Id="R8RdpoNQbPlO5YjfGsouH3" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="GtY07xfgm2HLBXg2YVRIVT" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="NRv4pTysJveLW9XGvfPMUA" Name="Recreate" Kind="InputPin" />
-              <Pin Id="HRp3cDGVMZzOosfmby1CYr" Name="Apply" Kind="InputPin" />
-              <Pin Id="R0tEohU2quGOHzDLNHjuQl" Name="Output" Kind="OutputPin" />
-              <Pin Id="CeQV8c4ecd9MbqfpemsJWa" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="1143,2876,85,19" Id="C8NwqNqD6ILLc6p2RfbiYT">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="HSKnAA40iBmMypWquosjiz" Name="Input" Kind="InputPin" />
-              <Pin Id="V5VWXzd9hOWM0waASHYE3P" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="S1eKbibHAiRPv3YyDmAhiD" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="AWChLWNtPI5NtpT0Kh3n4V" Name="Recreate" Kind="InputPin" />
-              <Pin Id="NIlJORKdtUgL0MKUyLfO6Z" Name="Apply" Kind="InputPin" />
-              <Pin Id="RGloaS7Psp5NZqFZMU5eBR" Name="Output" Kind="OutputPin" />
-              <Pin Id="LqGVV8kCrAvLVeREaH7jCx" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Pad Id="Ujb1lhhWjgBM0ZcqwUM9j7" Comment="Point Light Count" Bounds="753,3190,35,15" ShowValueBox="true" isIOBox="true" Value="0">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="262,2545,374,277" Id="BFpIykurQSmN7X1wVO2YtS">
-              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-              </p:NodeReference>
-              <Pin Id="E0btUUMuDHyNqHTStdgmnZ" Name="Break" Kind="OutputPin" />
-              <Patch Id="S8qWRGKFXYfN7qSb1A9hil" ManuallySortedPins="true">
-                <Patch Id="UJcvw7OHlxHNRWCE1Kuk77" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="GfR8q0YyfcMO7AaiY2Llty" Name="Update" ManuallySortedPins="true" />
-                <Patch Id="H2pPRbOWJKkOwvudK2wkGb" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="294,2632,189,26" Id="SqPrlheKxBYL7L4oqthJpr">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="DepthBias" />
-                  </p:NodeReference>
-                  <Pin Id="FdtIv2hQ1gkObNxGtxWwfr" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="QYoD58vYJ8zPwNWZGsv83B" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="P8BweTVMWL2Nm2Ept0iWvs" Name="Depth Bias" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="284,2586,189,26" Id="MTXhMvSKam1Pco6bHSP2NB">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="OffsetScale" />
-                  </p:NodeReference>
-                  <Pin Id="Jm2YOJlcHR3N40Tg72Uucu" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="UBCcupafUk4PlNoWDB0uS8" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="MwopZ6doRMLOkQcEWHjA0m" Name="Offset Scale" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="283,2678,189,26" Id="UN9Pn0Rkr5dPM9ySa1NXh4">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="WorldToShadow" />
-                  </p:NodeReference>
-                  <Pin Id="HiJcdPUlTOeQanackqEgmU" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="OqWbDL3Cr7QP5jfGRKohU2" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="SQGgwzdotOGO8iad5b19EM" Name="World To Shadow" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="274,2720,189,26" Id="VXuNoBcVG8pMGOfssQ5V3Z">
-                  <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
-                    <Choice Kind="OperationCallFlag" Name="DepthParameters" />
-                  </p:NodeReference>
-                  <Pin Id="PQ0NtpqbjqqPHzHjSXWTvY" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="CdF7hEDoLpEOXLne4oJm58" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="SySB10i0IWUPVah55hzzQk" Name="Depth Parameters" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="583,2657,41,26" Id="GXPEDrGnt18PdJ0QNYBKa4">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="Q6YUqJbXleRLJBGXVL35DK" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="KckSJS91jCSNbT3TP1huxY" Name="Item" Kind="InputPin" />
-                  <Pin Id="C0HB3knrk1QMqAb8t1vCNW" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="514,2676,41,26" Id="MZq72rtZDnoN6XCkSOT8j6">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Add" />
-                  </p:NodeReference>
-                  <Pin Id="BkPImN0dPkhMLSuLT9thyN" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="Oeu9QWkgDh7MOwOglBpmcC" Name="Item" Kind="InputPin" />
-                  <Pin Id="ODkAbSxA3LuMHHBejP9PUO" Name="Output" Kind="StateOutputPin" />
-                </Node>
-                <Node Bounds="406,2763,63,26" Id="UHF3ePEX09RQCgbMR5nzmE">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="AddRange" />
-                  </p:NodeReference>
-                  <Pin Id="JPJ3oCHdVRUPXOqysOZTc9" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="JRULzY6JpldNDzLTGzvYqg" Name="Items" Kind="InputPin" />
-                  <Pin Id="HY8R0aI8L2oLahGLV98SXl" Name="Output" Kind="StateOutputPin" />
-                </Node>
-              </Patch>
-              <ControlPoint Id="QdXQuy4GNa2OEdYSIruB47" Bounds="310,2551" Alignment="Top" />
-              <ControlPoint Id="OhhzQpYFFjHLOXumnCZBWg" Bounds="578,2551" Alignment="Top" />
-              <ControlPoint Id="IPpyPtIBztCPriJsorAGHv" Bounds="591,2816" Alignment="Bottom" />
-              <ControlPoint Id="GzNTtHhrLzqLNXaPciRv9l" Bounds="514,2551" Alignment="Top" />
-              <ControlPoint Id="LUxAbjujGY0QFrm2w43TEk" Bounds="517,2816" Alignment="Bottom" />
-              <ControlPoint Id="KGKcV6TZQPDP2l0K4DnlUm" Bounds="372,2551" Alignment="Top" />
-              <ControlPoint Id="RiG6DA7PAJlMQmZ5lMuPF1" Bounds="438,2816" Alignment="Bottom" />
-              <ControlPoint Id="N0gvzLtB0PzNJotRsrmAUt" Bounds="297,2816" Alignment="Bottom" />
-            </Node>
-            <Node Bounds="289,2874,85,19" Id="NzPnw2yJnxxPMFQxobQIIe">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="BCB9ekzAykTN8MTt5bO05o" Name="Input" Kind="InputPin" />
-              <Pin Id="MeEXVD4NiqiOurijCRkTjG" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="Dsq0zKXM8snL2uprybdXYT" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="GDDE8i8EfOOL0XSuwt21CU" Name="Recreate" Kind="InputPin" />
-              <Pin Id="II55QD9FpHrNECZM6nMJga" Name="Apply" Kind="InputPin" />
-              <Pin Id="VkWxgn6GBJGLSHOBDDCzG8" Name="Output" Kind="OutputPin" />
-              <Pin Id="ScCD9cHMZXGN0dhxTI1MDb" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="V4vaZat4m0DOoXhxR3DCQ3" Bounds="-106,1837" />
-            <Node Bounds="936,2859,85,19" Id="Mrq7KJT16UfP7I2PFB0AuW">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
-              </p:NodeReference>
-              <Pin Id="KrUe04PPNwAO856m5e6YnP" Name="Input" Kind="InputPin" />
-              <Pin Id="DgJNkyNo3rxOIQTNOq5GJX" Name="Element Size In Bytes" Kind="InputPin" />
-              <Pin Id="AvpfZYCnSqyPHsaYDkCyz6" Name="Offset In Bytes" Kind="InputPin" />
-              <Pin Id="QBXiSaHwh8LOtSfq5q5Opz" Name="Recreate" Kind="InputPin" />
-              <Pin Id="OFgT4RDXU6aL3C3P0G42Og" Name="Apply" Kind="InputPin" />
-              <Pin Id="IIlPtyWYOQTNVCs73ssDSM" Name="Output" Kind="OutputPin" />
-              <Pin Id="SssEBaUbezONH5zoDxRkni" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="Io86YvtdaUHOGaPvThTSiA" Bounds="-106,2761" />
-          </Canvas>
-          <ProcessDefinition Id="J8T83TqnngoMIIuhIdPJqZ">
-            <Fragment Id="RJB3hwPu0yaM7LHx3CBlel" Patch="THBwAFOt8a4N12lYwcnrXd" Enabled="true" />
-            <Fragment Id="JsMDmKgvJgZMUSuBai0Kww" Patch="UGljWRzqOR3QSAb5aYBiTd" Enabled="true" />
-          </ProcessDefinition>
-          <Link Id="Q7YkRpbDYqHK90lVQDklE7" Ids="AtuaGlLsVwdLwuDcypjZE8,LpTEIVyc8PSOOyUyDZbkR4" IsHidden="true" />
-          <Link Id="JkeKaG6EMcTMKlwgA0lCjG" Ids="LpTEIVyc8PSOOyUyDZbkR4,BbokHxueVN4OmkxaN5pjvx" />
-          <Link Id="ARmwybxtLWFNCJiNVyS7bG" Ids="M5A86MMZYg2NEyZp09pNva,QTeefJIWQ8WOff6JdiIVoi" />
-          <Link Id="TV4IPcMecoUONdgKhKFjo7" Ids="GY3SbIXBBQ7P4j44eGNAIB,DVVjMListXjLdoMbMRBlZS" />
-          <Link Id="RijCOiLVCYgLj1zQFwflYm" Ids="Cn94VREA8g7MHprI9AQAiP,K9AibQoXVq4M6AFZyQunLi" />
-          <Link Id="GjIU9ExDiIXL76fVvGTcuu" Ids="MZEKGFCllDcLZWQV8nfph3,I5sr01GB4l3NSIGe5Hioia" />
-          <Link Id="PfSzS0V0HEEL5p1Lr8NPJs" Ids="Ot2KRhSUscpNAaAXCt5lOG,GJjUx8Mhz1pLCYB10JvmNv" />
-          <Link Id="OvhuDw1TkA8Me52u7jBaWE" Ids="GklHXgQodDWPTTjQhWlNc8,HjUvcyNZ0JEP9GaToS5DRd" />
-          <Link Id="CgSK1bh9PdBMITb0qb4H5H" Ids="RwAAKON7h57O5QIH0dwhUy,E2IEHEPrsoPPxWMGdtMVgd" />
-          <Link Id="KztCGn7GBEzNplpxO6ZGjx" Ids="FiGuRyBGyfiQdd41s7AXGE,GuSvYAXS7D8OWn51WLyTJU" />
-          <Link Id="BhGGPfi4KL1MSIfYsBr3xm" Ids="SMY1H1G3ricQVq8PON9Umj,VZ7dFlmHtuuQStqOzGodNb" />
-          <Link Id="VzhFjBMwz6RLsA5C0itFSc" Ids="M4X9jHLl3nLQX8Rw8rN9mM,Ni7YWwjEzpBObVO4pgc6eX" />
-          <Link Id="Up5JUBkzVxPOtfTBh6FxVT" Ids="JFU94OJtpsTNZLHOCCT7aE,Hz0uZCk8HYDL5Hv1tP0XAh" />
-          <Link Id="M0sGtRrjf6IQapG1mdTc9O" Ids="KQkopUKAvl6McnjMH186qn,JYwfCsV2dCwNXN1jwgsHMu" />
-          <Link Id="L7BMffaoyJLLfZmJQ0orGt" Ids="GUb7id7WQXPMWSWeIFmQNx,GMMNkNW2L37MqSuNkE0Ttv" />
-          <Link Id="U85ohthGhNXQXybO7duSLN" Ids="LpTEIVyc8PSOOyUyDZbkR4,Od23u7jF2HVQN0nyxZe0qN" />
-          <Link Id="JN5qLqr6NbxMecD94OG9iA" Ids="SIreuv6T09PMlTCtgZ0rk8,KthM0PTFY0tPjU0WNdXbEU" />
-          <Link Id="EvrN82ujNzzOk84NvEo4PJ" Ids="TyAxVie1aNBPX9sxWq56Br,PBkvV1Ci1NaMd1H3BMOYrd" IsFeedback="true" />
-          <Link Id="JI6C2gIQnE2L168Fwv0LUO" Ids="CzCnaCBE2oOPLPCsKXuild,MgtnR94gvIDNfeR16Onh02" IsFeedback="true" />
-          <Link Id="LxhvOCSnGSqLdKCHgA2Sk8" Ids="QoeEs2NCif2LSN3gnbNbx7,RxrJGMuVJvINnbrwHniJ8Q" IsFeedback="true" />
-          <Link Id="MhPRMeF1kZ8PwJIF0GxxRI" Ids="SIreuv6T09PMlTCtgZ0rk8,CFb6EFh5cNQPRQUN0sOOgS" />
-          <Link Id="Ldn371Q8OqnN8TOLKYwhq3" Ids="GwunZm8c14COYpmWUOg19w,KvrXdSJvZRmMMaWmJQsiEq" IsFeedback="true" />
-          <Link Id="PLGvIc3cIS4OsA68K9Nhex" Ids="SIreuv6T09PMlTCtgZ0rk8,AceN2CnlaDYN2j8KZoWvHS" />
-          <Link Id="UYYG6swKG3qOmDcd3H14B8" Ids="RvdRYw30FxGPD71XjjKz9H,LvZPcvR14ejME75TxYWtXY" />
-          <Link Id="VjnK7PwEno1MPjRHxlMdaI" Ids="FepXhhqTxgaNmtGCczvGfd,AHPikePdeKZLrtpyXYWuan" IsFeedback="true" />
-          <Link Id="BpKGoOMv39eO4KemOCVDEE" Ids="QdBkaLHWgDqN9mtk31CZ6I,Jx9otizf3yWN1UsjqSXJwa" IsFeedback="true" />
-          <Link Id="MV585drnZTyPWgyB9d88XV" Ids="OPb5cS9Df9RNmJtXH1x8TT,VHmTl8JaMx2PWpRKzEysKe" IsFeedback="true" />
-          <Link Id="ON3kH8UDHgLPNewZsH3r0M" Ids="VocbaQGgwNDM0mNBAJs3LR,GqaVrkb1KeOM4HQmbXywRw" />
-          <Link Id="QeD8vZIFyzsMsNc72luVE1" Ids="Rx6sUAIWPFFQSxbo10Higl,BIIYXZKkQL8Py9T7xcs5Pl" />
-          <Link Id="PJRB3NGeDyQQEuRvUpfWOk" Ids="J6CwHaeQSdhMyutzQYMgNL,B3ey7TZuMXFO9hMlTJxCGk" />
-          <Link Id="RgiZBVqMdF5NFqNa9TnOXr" Ids="CVTtgyMzH0xOegdSxz9xVi,CB2i1yqDgylMI4tedkJaEb" IsFeedback="true" />
-          <Link Id="QMAa63tlMDSOJCW46Ztafb" Ids="FQC2rkgu8CNPV19bw1GBFV,CB2i1yqDgylMI4tedkJaEb" />
-          <Link Id="VryvtusRlKKOHYo28JBkjE" Ids="CB2i1yqDgylMI4tedkJaEb,KvrXdSJvZRmMMaWmJQsiEq" />
-          <Link Id="LqYIBB74xrPMxmT1unMwju" Ids="AZ4fNYJrDNhNj2jMn3Lwu4,MoI9UC9xTB9P2GZlokx5rn" IsFeedback="true" />
-          <Link Id="Il4oleCtrSOOqmR0v6alxM" Ids="JAy7EBFwxFdN5NA6y5zNqR,MoI9UC9xTB9P2GZlokx5rn" />
-          <Link Id="N9KOoQjfFQYOnQwUTCZQ1I" Ids="MoI9UC9xTB9P2GZlokx5rn,PBkvV1Ci1NaMd1H3BMOYrd" />
-          <Link Id="BIELTV7jqzHNAjU6GJj8Dk" Ids="JS9Me0Fv7SvNY5xTlaIZSt,D2nnCKB80CKLsxT61rREYd" IsFeedback="true" />
-          <Link Id="EDRHCsPRCFaOdG3Sz4jDWb" Ids="Mx7gFa6bS6wMNDFHskV2lt,D2nnCKB80CKLsxT61rREYd" />
-          <Link Id="DpSZT6pLpvCLOvqkHeMCO1" Ids="D2nnCKB80CKLsxT61rREYd,MgtnR94gvIDNfeR16Onh02" />
-          <Link Id="FVADJhxhXFSPb4SSCvdMv6" Ids="BgYAEM60fBRNox6voR9zOl,TBHc38wkDx2OUlCRR8tJ2L" IsFeedback="true" />
-          <Link Id="VQC2KT1QTEMN2T7hTUa09b" Ids="K91xK0N5x50PUHWsM7ezWK,TBHc38wkDx2OUlCRR8tJ2L" />
-          <Link Id="JWkcd9rS5wDNlmCmwBxbH2" Ids="TBHc38wkDx2OUlCRR8tJ2L,RxrJGMuVJvINnbrwHniJ8Q" />
-          <Link Id="IB4IM1Uvf8XOh6h47zYHGP" Ids="AceN2CnlaDYN2j8KZoWvHS,QVYd0Np6o6BLcvIdTeRfO7" />
-          <Link Id="Sox1DZTdPK2NaPpfX2DfhS" Ids="C6EXwn8KpW5NUMT6f7yY5Z,Iam28afpcm9LISSIhKgMnD" />
-          <Link Id="HTU8qohg5P4Ldpp5ViJmDy" Ids="Oqm6bWqbuoXL23NJuJqLe4,Jv6cyhJiSdYOKdMosA4HbW" />
-          <Link Id="SNkgrEsZDYuL9AbjT01uK8" Ids="MwOZZG4nuunPGSyxZ7PWqj,OHGZMXg2fkjOYYqDplYb1X" />
-          <Link Id="IL6xDC113b2MuYGD5MdoTr" Ids="VFUPSzK6AUDPjSix5iSnfD,KlBVmL1NgRbPa690MkbVsN" IsHidden="true" />
-          <Link Id="Rzkdr0prVczLDs5YLnAyfK" Ids="VDAzJqGAM2jLOviuNFkqY7,VFUPSzK6AUDPjSix5iSnfD" />
-          <Link Id="R30m8cQ39OhOridQtUlTqT" Ids="BP5eWaKNSe9LXNmm8T5gDA,UzFQ8eKEQyzMRbTkBdb5bu" />
-          <Link Id="HHXQXn56GnaLFDRlAFuYPe" Ids="VJBEnF9mT6vOGPLKiI1S9n,IeB4Fxo3AmqPa5TV0grqOn" />
-          <Link Id="VK2mSK1AcyzN6x4ToKWolL" Ids="JZ7ybZ9LfoELB4s36WEQY2,Ubxe9G8SbRTLZGvn5IBbdU" />
-          <Link Id="SGJa0RghYpmNfOZfCxlF5Q" Ids="KO2rKTod9dPMFFlkS7HA0K,G4JSiL0mBEdMw7lRpLcXdS" />
-          <Link Id="RTQOI4AdkbYLnvRcXKmiMb" Ids="CFznCZh1LUBOgEp5chNn72,PWnUVwoHOa2OCFlkTqAAEX" IsFeedback="true" />
-          <Link Id="TB5fZ2OCQiDPNJ88bAvxcq" Ids="PWnUVwoHOa2OCFlkTqAAEX,AHPikePdeKZLrtpyXYWuan" />
-          <Link Id="CXIIWIlGrpHMPeEKcH0llh" Ids="LvYmSHhLUjgOvF0VswHoon,J5NTlPg637XLBh1QJXMzq1" IsFeedback="true" />
-          <Link Id="FbUEEFYuWSdLnfRnTG595v" Ids="J5NTlPg637XLBh1QJXMzq1,Jx9otizf3yWN1UsjqSXJwa" />
-          <Link Id="CScggH3oiajPm1uydmjhWV" Ids="GttD9HPfpLhQdM9On9ZEvV,GNR0pZZBPiqOkmHl1WFxHh" IsFeedback="true" />
-          <Link Id="JEK6SFFnMQ5MJ4IYyi38W8" Ids="G4JSiL0mBEdMw7lRpLcXdS,GNR0pZZBPiqOkmHl1WFxHh" />
-          <Link Id="PH7SEHpwZoLNnJUXDq9ecJ" Ids="GNR0pZZBPiqOkmHl1WFxHh,VHmTl8JaMx2PWpRKzEysKe" />
-          <Link Id="ERcBadc0MXEMp2fPrsFyCW" Ids="LRUeRw3YZk3Px0UFx1Ek9m,IwC0eUs243CNS4kRvfv3qg" />
-          <Link Id="OjndDxqXe9AMN2e27V7gYS" Ids="LjDRNtL4rvwOd7uv0or3H1,SrxqFV3xEoAPAnAXoFmi72" />
-          <Link Id="JSIw3yOYRBhNMzs3n2GHkD" Ids="SeGEWP1HjQlOBy1zYU1owo,GYc01OWlGGEOLic4ZPoGQA" />
-          <Link Id="PfV91nmCuaSMdruTppZydz" Ids="RUDDJDxN6V6L79SYMzO4AI,Cm4CcKYY89WLdKiIeh7Ko7" />
-          <Link Id="JbcIwjEF5HBLnisuKcsVAN" Ids="Kbt2Q8t4cqfN5AkxBfstRn,HrWO5lH8ApmLIez808Mze3" />
-          <Link Id="SagF1jhsyi3OzPuVofHWDX" Ids="PYzbslezMMLN4RcIr74Qyb,Q6f4Aj5SQJ2LagU8jdz6CI" />
-          <Link Id="ClKUtPgXAGoOvFsbsqBZkk" Ids="H7R5ETG7l1wLgWtD3MvCjB,QRzov8J4o0AMhOijvydlz6" />
-          <Link Id="C5Ffy7s9xIfOZtjE3bY1HJ" Ids="E3XInlp16igLaCXpulwUkx,LbES1dldW5hQdVFm66Scx5" />
-          <Link Id="Fu8F8YKy7cKMcTDFwfP5R9" Ids="HXqoVKww7koMvQFSHO15Jk,I0LxWcs8GHfPuG1iOo3c4f" IsFeedback="true" />
-          <Link Id="L87fgyBgSTUQSjkl6p8nPa" Ids="HXqoVKww7koMvQFSHO15Jk,S0bKqqYlbNaPOSX1f1btSz" />
-          <Link Id="NYRZFZjp6HlLWmLGjyrwC3" Ids="O1uak8tu1CXNXDfUBVsiKs,I0LxWcs8GHfPuG1iOo3c4f" />
-          <Link Id="LnKMZph3huiQVgrSTxctUi" Ids="LLbzBacZCTuOUAveYN9qhJ,A8MPHbwc8aQQTgqyETnQaZ" />
-          <Link Id="HVcsdNvUI6vNLqd3JaJSVj" Ids="Ri880ax0sFtPGxKKTDd1wH,EDMnpMThjeJN7g5CxQ3Ggg" IsFeedback="true" />
-          <Link Id="SkMBueAg7RDLWQ32FdY4Ek" Ids="ArhjJqTfsHuLbTtmRK1NvX,EDMnpMThjeJN7g5CxQ3Ggg" />
-          <Link Id="CKHna8myBD3N7U9JgE0CDT" Ids="Ri880ax0sFtPGxKKTDd1wH,F5PMc8w1WMtQPEfe7zAWIg" />
-          <Link Id="TxixlSQ5HvLN0onCwQHjWR" Ids="O7cGMveuU3YN08BlRso52h,LPxiUAMuca1OqCKvPjITq4" IsFeedback="true" />
-          <Link Id="MbHO95oqaCSPhqq8XAfkN2" Ids="O7cGMveuU3YN08BlRso52h,GBQIsQjgsOJOtuU45TZvYg" />
-          <Link Id="VcfCws73tIwLtIbFda3Vll" Ids="NgnSCaZIJGaQdVEWYagaeE,LPxiUAMuca1OqCKvPjITq4" />
-          <Link Id="VKqPp86f230PKIguMVRgYN" Ids="H66YlqQxLbgQVGK4ZcNSwk,TbXlbSlhK04PIUyACFOYgX" />
-          <Link Id="CejnJfDtCv3N370CWoNlND" Ids="SvjvBxB1h8xQMoaWI3o1dc,MpQ6rSnIRmlOpKQpIGgler" IsFeedback="true" />
-          <Link Id="HeyB3i1KsjlMRQNvMUzKrd" Ids="P1EmDzjyRAENbZU3aODZm7,MpQ6rSnIRmlOpKQpIGgler" />
-          <Link Id="RCqKZDkMKSGNZw1XVYxvvZ" Ids="SvjvBxB1h8xQMoaWI3o1dc,RhcudGaiTUOPxkDa864Ox1" />
-          <Link Id="Sc9z9xJh7E4L8VoKMmfu5J" Ids="T63nxKhTj4tO5d32sTyhOt,Aw8u4UC7rcILR3oVvmHnp5" IsFeedback="true" />
-          <Link Id="FolNaHmVoTwLf47RzKQ1Op" Ids="T63nxKhTj4tO5d32sTyhOt,UEEKvXHOnLkQFoTyuzzHDK" />
-          <Link Id="BJyAAss0Q3aMy6nqFwPNfc" Ids="CDXsDhmgjf4PQMYdAtZw6z,OGREKlR63V6NYsNNhIXYkv" />
-          <Link Id="Cugv6oK3nkGN7vfxYMKIEe" Ids="D9yFiBfrA9KPtmuaYuy5af,Aw8u4UC7rcILR3oVvmHnp5" />
-          <Link Id="B5Pu9JqNC1PNH5ju1X6UdR" Ids="Nw0BZ0FaayEO8VYHyaF9kI,HUlG8C5GY41NZQYXnrwq7z" />
-          <Link Id="AKvIn9ixopIO7w5fNVI8Yg" Ids="NJ5RhHpw7SSOZDfk7AU3lW,Viphair5txPOxUrWgaagoK" IsFeedback="true" />
-          <Link Id="CguHMAsNhD0LTvQOy9dUC1" Ids="NJ5RhHpw7SSOZDfk7AU3lW,SRyw21e6tbgLWcvndmEGC0" />
-          <Link Id="UL467ddpHWvP7uDR7mtGVK" Ids="EFMG0uG8BreQJydJZNgNYM,Viphair5txPOxUrWgaagoK" />
-          <Link Id="NCNL5mkA3ZiQIeALpllpv5" Ids="S5hzSD8jQ0oN01Gx2FF3fT,DNNOevvgPWhLZ3Q06KSfEM" />
-          <Link Id="RnoLEUgR6USNPUN8jnQ446" Ids="GYl3bq4XadWLx4xVW2LTOS,L9DN9MfFxSaP3v6KqwHOUh" IsFeedback="true" />
-          <Link Id="Kd3U7kg4pdkL0jO6XZu47k" Ids="GYl3bq4XadWLx4xVW2LTOS,BjlIau8qyiZQPSd8sferIK" />
-          <Link Id="MZ40xPszpptN3KUO9mlLGe" Ids="L9WloKx3mU7PMOff5OrdUg,L9DN9MfFxSaP3v6KqwHOUh" />
-          <Link Id="QBoLay1iLtzMwrqwd8RVhI" Ids="H0jqxS1pg0jM7NB6kqC3GE,SFfROyM0VMlQFBgJUxTABZ" />
-          <Link Id="PzYygz9ZQeWOVIguPHhi1Y" Ids="LSBa99CEHvlQRyP1kvh4s6,PYzbslezMMLN4RcIr74Qyb" />
-          <Link Id="D5hXQu5jFIONJXrEYyzgmR" Ids="CxV6GLXBD0VN2gDakC1t1l,SeGEWP1HjQlOBy1zYU1owo" />
-          <Link Id="LJqtZTtwDjOLWc2XKkuiTC" Ids="Viphair5txPOxUrWgaagoK,GYl3bq4XadWLx4xVW2LTOS" />
-          <Link Id="JABo3PEw4TrONEXXVopcWz" Ids="Aw8u4UC7rcILR3oVvmHnp5,SvjvBxB1h8xQMoaWI3o1dc" />
-          <Link Id="OfKmAFK3aKsQadGlESyAFN" Ids="EDMnpMThjeJN7g5CxQ3Ggg,HXqoVKww7koMvQFSHO15Jk" />
-          <Link Id="HlNhagCrlDwLx7wv9yTWs0" Ids="UNDrqgFE5uKLty5LFby4cs,HGGWeKCI4eGLgkSOD5wqYC" />
-          <Link Id="Fl53m8HMgqNMVUcWRrHQp8" Ids="SFfROyM0VMlQFBgJUxTABZ,TygSsmZBxb3PhaLHSh0kZM" />
-          <Link Id="CZ7v6YsMhaZLJOgevxOdmS" Ids="Cm4CcKYY89WLdKiIeh7Ko7,KezWVByE0ebPQa1Zkn44Zg" />
-          <Link Id="HrFdumVLGpPPjHpFVRjizy" Ids="PBkvV1Ci1NaMd1H3BMOYrd,S6zXamZDMJwOa69woIV1vG" />
-          <Link Id="UhCt1rD62sINS80oAijITi" Ids="MgtnR94gvIDNfeR16Onh02,SNH2eUs1mKkMGg3aWrmPsa" />
-          <Link Id="RBCCKZVLUv6Ovglsz4LrUu" Ids="RxrJGMuVJvINnbrwHniJ8Q,TvrgwTwRsKTO1Je6s8RdnJ" />
-          <Link Id="FOsqDcblBWiP0XsAYxdog9" Ids="KvrXdSJvZRmMMaWmJQsiEq,V4vaZat4m0DOoXhxR3DCQ3,Jtx4uK1IGYIOoFJUp9nve7" />
-          <Link Id="FhME2KlLteROl26yyekZQB" Ids="FAYkVzmOv4rQNGxCJT5bZ8,NsleN6vwG0oP7NKv6NchvC" />
-          <Link Id="KOhmcQMxb4RP0TD9My6cKF" Ids="NsleN6vwG0oP7NKv6NchvC,B0lIPTL63uLPZwG44Mx2i1" IsHidden="true" />
-          <Patch Id="THBwAFOt8a4N12lYwcnrXd" Name="Create" />
-          <Patch Id="UGljWRzqOR3QSAb5aYBiTd" Name="Update">
-            <Pin Id="AtuaGlLsVwdLwuDcypjZE8" Name="Input" Kind="InputPin" Bounds="547,272" />
-            <Pin Id="B0lIPTL63uLPZwG44Mx2i1" Name="Output" Kind="OutputPin" Bounds="614,2431" />
-          </Patch>
-          <Link Id="D1QTmcYtkZUN8LOpQvtXai" Ids="LPxiUAMuca1OqCKvPjITq4,MyMImd1X7gnNiYPm34ta9h" />
-          <Link Id="RMowL6ZZeCJOrKaxCvydFB" Ids="MTCJjv4PM8rN33E12KXwHu,PWUuucfPBcIPV4TG2BCSFt" />
-          <Link Id="K7Y89x0NNMvOGCfv6RdsnN" Ids="HcSN8kkQs5EOISMCcCfzYs,OT3kLfvjy9INL67VWN9lf0" />
-          <Link Id="VjvlGeEHAIPMCpoOL9hlaQ" Ids="KpL44DuWybqPwKJ40vhGJX,QASwuwTCuo4PyQy6UKy6x6" />
-          <Link Id="UIODcBxdS3eMPsIyaVYFqF" Ids="AHPikePdeKZLrtpyXYWuan,DzKZQCxakA5OgnEMjNJwgi" />
-          <Link Id="AAOCLK0k2T3PQGQmwFuI0j" Ids="Jx9otizf3yWN1UsjqSXJwa,L7Ojq1AxwbkP7t6a05kD0N" />
-          <Link Id="BwUXJL5lJN1Ov0dBbvJoZN" Ids="VHmTl8JaMx2PWpRKzEysKe,HSKnAA40iBmMypWquosjiz" />
-          <Link Id="IXxCvwSxN4sPVtNf9VGYHk" Ids="Ujb1lhhWjgBM0ZcqwUM9j7,TbtnfD4ljnMNxNJjL8mvaY" />
-          <Link Id="Equgt5Lo0QAPn5ZpMdSCmH" Ids="SKbiApyNJrbLYqmNkkmyjY,Ujb1lhhWjgBM0ZcqwUM9j7" />
-          <Link Id="ToUEJyekihBPtb4DOLW0Oy" Ids="I4ny1mKiZkdLwRxBoehOFA,QdXQuy4GNa2OEdYSIruB47" />
-          <Link Id="Oa5zgQbZvdkLqiJDvydwck" Ids="QdXQuy4GNa2OEdYSIruB47,Jm2YOJlcHR3N40Tg72Uucu" />
-          <Link Id="PXOx4OyxmNsPicaSDX5iR7" Ids="UBCcupafUk4PlNoWDB0uS8,FdtIv2hQ1gkObNxGtxWwfr" />
-          <Link Id="SfEPJanDIFaML7ckjAmRRH" Ids="QYoD58vYJ8zPwNWZGsv83B,HiJcdPUlTOeQanackqEgmU" />
-          <Link Id="OPjXqLewQU2OFufEF6a0SB" Ids="OqWbDL3Cr7QP5jfGRKohU2,PQ0NtpqbjqqPHzHjSXWTvY" />
-          <Link Id="H3QolVMoBZdLYs4Og6xL7S" Ids="OhhzQpYFFjHLOXumnCZBWg,IPpyPtIBztCPriJsorAGHv" IsFeedback="true" />
-          <Link Id="KY6CgfGribNP9KrVnNk2C2" Ids="L9DN9MfFxSaP3v6KqwHOUh,OhhzQpYFFjHLOXumnCZBWg" />
-          <Link Id="VCOA64M2ZFiQciUlOwneMU" Ids="OhhzQpYFFjHLOXumnCZBWg,Q6YUqJbXleRLJBGXVL35DK" />
-          <Link Id="Ju3royyenFDNaM9zy6Hqkl" Ids="MwopZ6doRMLOkQcEWHjA0m,KckSJS91jCSNbT3TP1huxY" />
-          <Link Id="NhIO5vPDlvbLFaOjuJmePq" Ids="C0HB3knrk1QMqAb8t1vCNW,IPpyPtIBztCPriJsorAGHv" />
-          <Link Id="ACdcHS32XC2QI2qbfVHouK" Ids="IPpyPtIBztCPriJsorAGHv,QJC24pEeExwPdOblgD1JFE" />
-          <Link Id="DZRV1X2Vbd2L8XVt0pKW8Q" Ids="GzNTtHhrLzqLNXaPciRv9l,LUxAbjujGY0QFrm2w43TEk" IsFeedback="true" />
-          <Link Id="T8MPel74W0MOLiGjd0Zl4P" Ids="MpQ6rSnIRmlOpKQpIGgler,GzNTtHhrLzqLNXaPciRv9l" />
-          <Link Id="UeNm6SnidhxNeBX9IgbfmZ" Ids="GzNTtHhrLzqLNXaPciRv9l,BkPImN0dPkhMLSuLT9thyN" />
-          <Link Id="B9CM5lwnRKqORUm4eMD18C" Ids="P8BweTVMWL2Nm2Ept0iWvs,Oeu9QWkgDh7MOwOglBpmcC" />
-          <Link Id="P3ekgqD2a0OQX8497cThq5" Ids="ODkAbSxA3LuMHHBejP9PUO,LUxAbjujGY0QFrm2w43TEk" />
-          <Link Id="QGQZUlwixf5P5tnDLwAjdh" Ids="LUxAbjujGY0QFrm2w43TEk,SdQ0WZMq975PXnu3q9gagT" />
-          <Link Id="AJDRiXvbFUnPmCyRQOuYZK" Ids="SQGgwzdotOGO8iad5b19EM,JRULzY6JpldNDzLTGzvYqg" />
-          <Link Id="QNmcFrw5667LWiUQBvXw2c" Ids="KGKcV6TZQPDP2l0K4DnlUm,RiG6DA7PAJlMQmZ5lMuPF1" IsFeedback="true" />
-          <Link Id="DtJlapjNVyzOv1BFc0hRT7" Ids="I0LxWcs8GHfPuG1iOo3c4f,KGKcV6TZQPDP2l0K4DnlUm" />
-          <Link Id="AzIJhJktsyGLZ7j4HvC8Hj" Ids="KGKcV6TZQPDP2l0K4DnlUm,JPJ3oCHdVRUPXOqysOZTc9" />
-          <Link Id="HsrYdNMqrCJM0OXAeJfueP" Ids="HY8R0aI8L2oLahGLV98SXl,RiG6DA7PAJlMQmZ5lMuPF1" />
-          <Link Id="Vx6FlxnPqtdM49bTRaS0l1" Ids="RiG6DA7PAJlMQmZ5lMuPF1,SLyShMNqyZuMN24bXu464M" />
-          <Link Id="LYOUc48xNowM32dtZv18ou" Ids="SySB10i0IWUPVah55hzzQk,N0gvzLtB0PzNJotRsrmAUt" />
-          <Link Id="EsjDfy6fMamLl6BZ5yvl7y" Ids="N0gvzLtB0PzNJotRsrmAUt,BCB9ekzAykTN8MTt5bO05o" />
-          <Link Id="Iq1tVjo9Sc4MI9edltSKCH" Ids="MwsiUN4bcwrLbpPSMWRtPQ,LvSgXNqnIrzPTz3HtITmIu" />
-          <Link Id="PlBpF468wc8OOPwnJ7GHuC" Ids="SUBczsByi1oO3q1qZabsbV,Tu8maN4RSRKNVGPtjMf1gm" />
-          <Link Id="FUB44j4ES96LJ9z80KmaHy" Ids="IulOUYBeSkoL2rwqgAtjmI,FjAJ2JmMsThLGxiBaHqBGW" />
-          <Link Id="OSNhD0XvFjHO61gBeiO5Nz" Ids="LvPQmQYT9URMFSAHKjW6Xf,QZJsfMwJIJBMxzww4ws9B7" IsHidden="true" />
-          <Link Id="DbZhtD4yLDZNTOrwLm1z69" Ids="HnKWqtfeTMtOiol7FZiPAE,LvPQmQYT9URMFSAHKjW6Xf" />
-          <Link Id="JZIHZLsUgZ2PaUuPq7y3XZ" Ids="PcAqkJW75g9M0Y1m1qEXUn,TsvQnCAkwZhMsr6XR97Nyu" />
-          <Link Id="BDf9Skgu23KPLIdZQYy0Gk" Ids="SIreuv6T09PMlTCtgZ0rk8,MwsiUN4bcwrLbpPSMWRtPQ" />
-          <Link Id="Js9nWQIpULcM4NSARr2Uck" Ids="R0tEohU2quGOHzDLNHjuQl,OUytWbHYzEuO3y21bPbHab" />
-          <Link Id="SMdX6S52KnJQOXDyhxCcuF" Ids="SgJlEm3UXzHPc1iNiHPQIe,QeHf8DR43g1L5S6aHa9cdI" />
-          <Link Id="FYJEk2UZdhdLSlJyOTi2WJ" Ids="DewzWILu0JFMcCPbRY0W4z,Ej94gf8M191O2wUQr96uLF" />
-          <Link Id="GY5H4RnNIXuMaAqCOn73tH" Ids="KovtxbJRE45Oq3bzD99MHh,URMu8GqeetBNwWs5ghbCzY" />
-          <Link Id="RLLuEWKEjpJQQWqyIB60wE" Ids="Ubxe9G8SbRTLZGvn5IBbdU,PJrxwtf3EAmLblvatyIzfq" />
-          <Link Id="Ob3DzI8QmdrLNdyH3TpRU7" Ids="URMu8GqeetBNwWs5ghbCzY,NPfmZZKXTUdMrbITA8FnpE" />
-          <Link Id="OT2iRJVLCAiN9ZjvtH3xqx" Ids="UoWfzErKp3tQOTonCPyYRy,J5NTlPg637XLBh1QJXMzq1" />
-          <Link Id="I47iP6rRuQNP38cYmBuGAT" Ids="Ej94gf8M191O2wUQr96uLF,FJSkquNGvVZLo6Sdf2uy53" />
-          <Link Id="EQkvHP7vtMbPu1DrftVFqj" Ids="VAVFRSx44S9MyjZ3nGrBv4,HXWKQ1ApJpcPh8C7YkosB2" />
-          <Link Id="GsYXpgu84bXQPUy8oDUM7A" Ids="HXWKQ1ApJpcPh8C7YkosB2,QxPOJbdIql6LxBqVpz5jKy" />
-          <Link Id="VsH6t2BQGI2QLHe0gHp5h2" Ids="GhPEGN5anMgPsZx8uWLlYw,PWnUVwoHOa2OCFlkTqAAEX" />
-          <Link Id="EJMF5rXgTqALXNUYsjUHqW" Ids="HnKWqtfeTMtOiol7FZiPAE,SgQaN45NbzfLXVHVityhbr" />
-          <Link Id="DPI1VahBshVNQmVjr8K6sT" Ids="Rn6jziApTJQOOFXuHv2SIu,U7T4movu5BiPFkPUd825J5" />
-          <Link Id="GMgikErc6dDN1LKnnd4N56" Ids="Rn6jziApTJQOOFXuHv2SIu,HItTMNhmrLyLvChizwcxmg" />
-          <Link Id="OV93zWSOyeFMygjzu5wBtr" Ids="JgdTNYXZXjGO9vR8fb8c5C,GDYdWmGHB5NP9OTc6rysH5" />
-          <Link Id="JRdvHOt080RPo69B0eLkAu" Ids="DAOJ29fH3JoN2q54759rxi,BZNDC6hA1XVQamgaxXauDC" IsFeedback="true" />
-          <Link Id="UDyRWGqwkJpPxmSNWcnaDP" Ids="TxM5Lviu1FtM422IYhI8Bh,BZNDC6hA1XVQamgaxXauDC" />
-          <Link Id="O59ooD4MfIXPdQx7HFUcft" Ids="BZNDC6hA1XVQamgaxXauDC,AN7UWR8TIKsPhdO0ePKB4D" />
-          <Link Id="P5SseH0rBf3NGaNJC4em1G" Ids="SIreuv6T09PMlTCtgZ0rk8,FUepA0oSPVGNsc4fvNqJJO" />
-          <Link Id="Gd2otovUil6Noy6PFRTfpg" Ids="VocbaQGgwNDM0mNBAJs3LR,IRC29P6JrknMvO6geFOm26" />
-          <Link Id="Qupsr0VwY05Ob4n6srqwqk" Ids="FUepA0oSPVGNsc4fvNqJJO,Fj2e38W72wKMZjJb5Vwhmm" />
-          <Link Id="Iqhb3c19MD8QIvdA2xEotX" Ids="CTxGS1hPxtfLFI60FpHNhZ,N4OqZEW77Y9NKLoCSpu5Im" />
-          <Link Id="N6yjNrfwY6FNKTLYcRvwCT" Ids="KP7f80TVAsbOFDrJWeiQFD,FagqfN8fFmdOZLmYSs5THL" />
-          <Link Id="Kglx6sFSlBuL19RKL5NjZ7" Ids="J6nQ4omJ1vANtzQQUJXyat,RASXhdcMGPHL6scM5yWI5n" />
-          <Link Id="Ef3uxTQrRSjPOrgwpFblsX" Ids="Grxcdfa0TwCLQ9qnqXsIFS,N6RPCh6SujiOjO5NUB55LN" />
-          <Link Id="FgpbNlhKrLYOuILvmd6SC6" Ids="SSTmV5Wlj3TOtZnlEzd1dc,CsFuUxACG3SPoOlOdrSLxS" IsFeedback="true" />
-          <Link Id="Eh1Bp8w7nmWM3c4M2Xg8Vh" Ids="AL4a9CXuwCLOeKqQdzAZzF,CsFuUxACG3SPoOlOdrSLxS" />
-          <Link Id="RrzUrRVEcxkNN0RSbek0JK" Ids="QJgkmTaU9VZOG5yot78eeB,ECzSZeYQrhlQRpZEzRgZ44" IsFeedback="true" />
-          <Link Id="AcDmUmiLPY2QR75HxGmFGj" Ids="CsFuUxACG3SPoOlOdrSLxS,ECzSZeYQrhlQRpZEzRgZ44" />
-          <Link Id="DD6LIiIuB5fPuYI6VEDxJu" Ids="ECzSZeYQrhlQRpZEzRgZ44,KrUe04PPNwAO856m5e6YnP" />
-          <Link Id="RLzHivy03oUMxDHN4eZzXS" Ids="OYCVWYSgYb8N6AVgB0Z5JZ,EHr8tGygaNfLlZJYlOtwMX" />
-          <Link Id="FgKUiaOxPORPj3onZ9Xh4W" Ids="RGloaS7Psp5NZqFZMU5eBR,KpeZim2Cz9tLxjKzwSnWLF" />
-          <Link Id="EMMdwmdjKwFONIqhZwj6cZ" Ids="VkWxgn6GBJGLSHOBDDCzG8,QezHx76pAroPierYo5SVD5" />
-          <Link Id="VLfINzeCptPMuengdVsMac" Ids="F4pMHQgqZB5MKY9R8CUjsw,RKesi8dX5BNN1xgA2LXWkX" />
-          <Link Id="RLVgbwIUuUbPBAF3lNODBS" Ids="IIlPtyWYOQTNVCs73ssDSM,O3GCnhSjKewNZfzHQI4Fhq" />
-          <Link Id="Rxt6tTOIVWkPlw1KBYwHR1" Ids="UKpn9z528hULJnWLUjJotB,Rwf9imM2P4zMkAW6Pel8Fq" />
-          <Link Id="QBIthCUpmdzNhBbDeWl3FY" Ids="UIRYe3mMPm0PidPwXjMTSf,L7Z0OpGDK3tPzWwuIVVmlX" />
-          <Link Id="Oa77z2CSsKUPej5j8tLkEg" Ids="U8dshL1Ioj7PUI9WEHzCsj,GTOQi69RZFfPzGYULW4wqc" />
-          <Link Id="Fe0g0xWIUctLr2UtdykCE3" Ids="SYneiBMaXv7Mf8WptsLcwR,KuMN7NTLRS2QOBrWM2c7DC" />
-          <Link Id="NJh5y8VfdhCOP7pllvV8mY" Ids="QSWG6a3UTYbO8q4DZzIDxu,Io1yhlmk5KSMHEGIkafGYT" />
-          <Link Id="RJEF6GTFjB6N716OWUeh2W" Ids="OKRIM6pUMJ7Pd9roAJ1q9p,Roi62KJglQDNSod2pYFcFW" IsFeedback="true" />
-          <Link Id="PW5CgIrHwMuPlPAykVL4R2" Ids="RcJLuKSlixtNCgXBLuqWtf,Roi62KJglQDNSod2pYFcFW" />
-          <Link Id="TQ7LMuD0iFzO9OoWBbcULn" Ids="Roi62KJglQDNSod2pYFcFW,AL4a9CXuwCLOeKqQdzAZzF" />
-          <Link Id="MIWvr7OirtBL5zU9tFXKX1" Ids="KffoUwPCvbfPgq5bwzkGys,OKRIM6pUMJ7Pd9roAJ1q9p" />
-          <Link Id="RL5UTUKbDA2NwLPFk2kN5j" Ids="BqIkiLYKOHSNrUeXUVCbDL,IxTkhy30MywO0EYmy3Ys1g" />
-          <Link Id="OzLGHlH9uxOL3CqUOMbzLJ" Ids="EU3346LPwhVO8tvs0R2zSi,CbbA8LYJ0XJN2mtcR5shBv" />
-          <Link Id="VO2KDmQ2F1MLxlqINlXFlg" Ids="Jtx4uK1IGYIOoFJUp9nve7,Io86YvtdaUHOGaPvThTSiA,Fv4TZILVb6GPGrZNlr5izW" />
-        </Patch>
-      </Node>
-      <!--
-
     ************************ ShadowCatcher ************************
 
 -->
-      <Node Name="ShadowCatcher" Bounds="557,640" Id="OT0Ny3hWfFVPH86wgBHUDI">
+      <Node Name="ShadowCatcher" Bounds="514,355" Id="OT0Ny3hWfFVPH86wgBHUDI">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="NhQUm5U58nLLIfFbdpubeS">
           <Canvas Id="TGNklbSH9OhM4EJKQNyrwO" CanvasType="Group">
-            <Node Bounds="1032,1122,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
+            <Node Bounds="754,1098,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
               <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
@@ -1918,17 +30,17 @@
               <Pin Id="ChfH4QpRGwHLciNOwh20Oy" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="PsNo2ehteioPThgMNATyIa" Name="Output" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="884,869" />
-            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="1044,864" />
+            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="819,849" />
+            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="981,842" />
             <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="585,1236" />
-            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="843,743" />
-            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="1215,1102" />
-            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="922,763" />
-            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="1130,1061" />
-            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="1177,1081" />
-            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="1219,869" />
-            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="1240,898" />
-            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="962,795" />
+            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="777,716" />
+            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="937,1078" />
+            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="859,741" />
+            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="852,1037" />
+            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="899,1057" />
+            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="1156,847" />
+            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="1177,876" />
+            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="899,773" />
             <Node Bounds="583,1173,85,19" Id="Iv8QmhFRdfxO0nnglV0UEB">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -1967,7 +79,7 @@
               <Pin Id="CUAksSoURmoNEvLtxSOCuh" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="H32bPBTM1KfMeVYKMBofja" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="567,971,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
+            <Node Bounds="603,966,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
               <p:NodeReference LastCategoryFullName="Stride.Materials.MiscAttributes.Transparency" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Transparency" NeedsToBeDirectParent="true" />
@@ -1979,13 +91,12 @@
               <Pin Id="Mt9TDjWb1AKO9dCzjiKKEA" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="FwtCYbbNCR2QGPh7hPEGWZ" Name="Output" Kind="OutputPin" />
             </Node>
-            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="589,899,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
+            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="625,894,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
               <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector4" />
               </p:TypeAnnotation>
             </Pad>
-            <ControlPoint Id="NTiYitJLiPJOA7OZ6tjgMv" Bounds="512,959" />
-            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="568,849,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="604,844,35,15" ShowValueBox="true" isIOBox="true" Value="0">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
@@ -1999,19 +110,18 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="1163,824" />
-            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="1150,786" />
-            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="1008,837" />
-            <Node Bounds="1052,1007,188,19" Id="VvamwIIbEbCL1iB2OsvFHP">
+            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="1100,802" />
+            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="1087,764" />
+            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="945,815" />
+            <Node Bounds="774,983,188,19" Id="VvamwIIbEbCL1iB2OsvFHP">
               <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ShadowCatcherDataRetrieverRenderer" />
               </p:NodeReference>
               <Pin Id="UGLWhvLAFVJPej7ukTOgKR" Name="Input" Kind="InputPin" />
-              <Pin Id="JxJ1R64brF2NynIWOxbJ2l" Name="Compositor" Kind="InputPin" />
               <Pin Id="CbiESkhbWwXMJsm4gpo4aj" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="837,941,388,19" Id="UR5kT7mqBX9N5uwowJxlBp">
+            <Node Bounds="774,919,388,19" Id="UR5kT7mqBX9N5uwowJxlBp">
               <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ShadowCatcherRenderer" />
@@ -2028,7 +138,8 @@
               <Pin Id="Lt63z2kVv7nLEdrnarVzvF" Name="Depth Stencil State" Kind="InputPin" />
               <Pin Id="GbjzedfO4jTOfxZxje0Tyu" Name="Rasterizer State" Kind="InputPin" />
             </Node>
-            <ControlPoint Id="F3AyyIyfEfSMG2XbgFzicM" Bounds="1316,923" />
+            <ControlPoint Id="DhzIRqeDHaRMkSCcIvzqZy" Bounds="495,882" />
+            <ControlPoint Id="OkO5TLf1z7MQJq7zLO5eza" Bounds="515,997" />
           </Canvas>
           <ProcessDefinition Id="OYIyatA91KLOCZaTdgqMhW">
             <Fragment Id="AM3gkuf1OjILQKsjuNe11b" Patch="TZOUr2B4xdnNuWwnWeWSzU" Enabled="true" />
@@ -2061,7 +172,6 @@
             <Pin Id="T3rbnwZPaOkP0kSl9KxT0L" Name="Other Tint" Kind="InputPin" Bounds="1052,592" Visibility="Optional" />
             <Pin Id="F9Ch2ryYDJNOnFZL439Qpz" Name="Normal Offset" Kind="InputPin" Bounds="1002,557" Visibility="Optional" />
             <Pin Id="GDsQ4yX8w6vON5JYyXcvOw" Name="Output" Kind="OutputPin" Bounds="678,988" />
-            <Pin Id="EnYU4v26HOdOF1EtcmUIFZ" Name="Compositor" Kind="InputPin" Bounds="1316,923" />
           </Patch>
           <Link Id="KqkNeRJD7QrMBeLCBrQkO6" Ids="LfLGDNWACf6PcPyU7yvx2z,RokwtKJiuMtMoOdpj0PJmw" />
           <Link Id="BlR4dKYjCstQTtMA8zR1OB" Ids="IQ23JtO0pmQPBFLwLOgKfh,LfLGDNWACf6PcPyU7yvx2z" IsHidden="true" />
@@ -2087,8 +197,6 @@
           <Link Id="E0Tdq8v4VFJPRGTGherQuA" Ids="F9Ch2ryYDJNOnFZL439Qpz,IwGjrVhVfsdO0lcfiFVwOl" IsHidden="true" />
           <Link Id="FxRYiO7bJ8KNXoB4pZKhw1" Ids="PsNo2ehteioPThgMNATyIa,RwXCUSK1YuPPuYySbTJE3n" />
           <Link Id="ALMHthg3DywOWsZsUtH9O1" Ids="SgsBvnIOFTsMKZaLXrSStk,UzGUFmF6msIMa5xFfwYVvs" />
-          <Link Id="T70XvcleV5HQZqm880BA20" Ids="LggpBjjKIo1QZDfUO6hOMP,NTiYitJLiPJOA7OZ6tjgMv,OMebjSEg2RSQWjWtQSFGYc" />
-          <Link Id="G3NNOdLHCehQcI569RY7kv" Ids="GgjVEl7nWXCPnQJ6TxD9b6,QzYFfrYiuRmP6fThRgvlKE" />
           <Link Id="KxAba3kFxiJLeRg6sG25zQ" Ids="H32bPBTM1KfMeVYKMBofja,VahbffvbyERPASLGvZo0Ry" />
           <Link Id="VtSSUA8cqgGNpYqsjCRFKx" Ids="FwtCYbbNCR2QGPh7hPEGWZ,JBvzCmC1oxWPjyOvP9Qs2I" />
           <Link Id="RrSLfS8lygtQIU40lj7awQ" Ids="El6kUPGmZvrNWcVPmYvzsF,MARcWOXn1azO0C3HiNuPMz" />
@@ -2100,8 +208,6 @@
           <Link Id="SQvQyFgeZtNQFUx9NQVHxI" Ids="CbiESkhbWwXMJsm4gpo4aj,P80IxqYAC4oMO8PVlgw9NK" />
           <Link Id="I25cdjctTb4NwXljtMCYeM" Ids="LRcSB76aiU4OtbaMvR87LW,UGLWhvLAFVJPej7ukTOgKR" />
           <Link Id="CAl3KN6MstOL7zHQsXpT3Y" Ids="LggpBjjKIo1QZDfUO6hOMP,OdLONk91QdUPzwtSBen7Mk" />
-          <Link Id="Ja6w1jAQanIMBwwDVzQ1t6" Ids="F3AyyIyfEfSMG2XbgFzicM,JxJ1R64brF2NynIWOxbJ2l" />
-          <Link Id="TKPVjUiV5uFQUbsFP6qRZW" Ids="EnYU4v26HOdOF1EtcmUIFZ,F3AyyIyfEfSMG2XbgFzicM" IsHidden="true" />
           <Link Id="J5XzBkqHYdyP4FbgYSAUxA" Ids="RKwBZOlI7RoO4Va0RvLEzQ,RWf5ekrTlQ8Lyaf6zIIdoV" />
           <Link Id="F5q4Jg1UfP1L1sRA8sBIpm" Ids="IwGjrVhVfsdO0lcfiFVwOl,NDURo8ABoPOLNvwVPgEIt2" />
           <Link Id="VvpVIs1IzOGQL2zuiQPYBJ" Ids="FVv0P1PWUCVLVTPWyPbROo,HRnJGX2UMiBOrahbE9rSS7" />
@@ -2111,217 +217,10 @@
           <Link Id="ATDRD1cHn3rPLCtBmfgzwU" Ids="JnaZIUEH7aNObphuZ3JKMr,Lt63z2kVv7nLEdrnarVzvF" />
           <Link Id="N85bCRGQmtNQECLdAZ9Ijl" Ids="R7aGpGSYqLbNeQQWpOuxpX,BSTt5yUZY9sMIHpzjcFGEX" />
           <Link Id="NmAPGVWtavpQKqQ5cMCAqZ" Ids="GgjVEl7nWXCPnQJ6TxD9b6,J9hp6ot0OkiLCiL4pk1lyL" />
-        </Patch>
-      </Node>
-      <!--
-
-    ************************ SceneTexture ************************
-
--->
-      <Node Name="SceneTexture" Bounds="557,416" Id="RihFgYnXBQyQL5RDD3gwyj" Summary="Same as &quot;SceneWindow&quot; but returns a texture with the rendered content.">
-        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
-          <Choice Kind="ContainerDefinition" Name="Process" />
-        </p:NodeReference>
-        <Patch Id="D5GLzfCObX1O5KcfmTS9I5">
-          <Canvas Id="MvWCKDWE212MuHz8RtJyDe" CanvasType="Group">
-            <ControlPoint Id="BG0RTV7wEaiOc37WEontCg" Bounds="538,602" />
-            <ControlPoint Id="AMe2sritS0IMBbGPKbtOsR" Bounds="373,47" />
-            <Node Bounds="536,539,205,19" Id="RskIZiKMa0EPtOzym5MJVS">
-              <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="RenderTexture" />
-              </p:NodeReference>
-              <Pin Id="SkvdbFcPP6bLoM7QG9i7SR" Name="Input" Kind="InputPin" />
-              <Pin Id="Mdbe9ryhQMlPBQXElzMVmI" Name="Size" Kind="InputPin" />
-              <Pin Id="FvSkIalRMjROoLs75DiQyh" Name="Render View" Kind="InputPin" />
-              <Pin Id="H5kzVMJVBVKL5qo1jFS2NT" Name="Format" Kind="InputPin" />
-              <Pin Id="IUPrObbY0cdLo8jsbjtV43" Name="Depth Format" Kind="InputPin" />
-              <Pin Id="DtXH2kJJeMYLhtFkFa2GBI" Name="Clear Flags" Kind="InputPin" />
-              <Pin Id="SfqPWnHjshbPaLgEWawWLp" Name="Clear Color" Kind="InputPin" />
-              <Pin Id="FkjLNCK2CgKQLctTYIKcdJ" Name="Clear Depth" Kind="InputPin" />
-              <Pin Id="VourWkIEt0gNPk8AP9s1Jk" Name="Clear Stencil" Kind="InputPin" />
-              <Pin Id="FFqGoqow8v5LvLmn8kzvfQ" Name="Clear" Kind="InputPin" DefaultValue="False">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Boolean" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="T7MHqpk1NnwNiMzHL8YEUY" Name="Auto Render" Kind="InputPin" />
-              <Pin Id="LpwoVVG26pfOr3Ftv8fH8q" Name="Color" Kind="OutputPin" />
-              <Pin Id="PTxdFTSFUPFNynXPr8xll4" Name="Depth" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="O8cjJLqGOmFNEXKJzYFTQ6" Bounds="757,598" />
-            <Node Bounds="373,436,325,19" Id="TpikgVig49lMbC9ikcrxiM">
-              <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="ShadowCatcher" NeedsToBeDirectParent="true" />
-                <Choice Kind="ProcessAppFlag" Name="DefaultCompositorSetup" />
-              </p:NodeReference>
-              <Pin Id="FJKJg3uQMxzPV0TPIj8q90" Name="Scene Instance" Kind="InputPin" />
-              <Pin Id="Bx3ZVyKElXoNWQVcKaObAf" Name="Camera" Kind="InputPin" />
-              <Pin Id="Mz4zV97QbOrOS3Xk0cHNmU" Name="Clear" Kind="InputPin" />
-              <Pin Id="QG7gjpORBFdMvm2SNstirl" Name="Clear Color" Kind="InputPin" />
-              <Pin Id="M3LxE8v3LtDPuN52eL7LiF" Name="Post Effects" Kind="InputPin" />
-              <Pin Id="AdWTImOBUvAPjFJG9P8UXa" Name="Enable Default Post Effects" Kind="InputPin" />
-              <Pin Id="OU1hev0RQA1Nq9XWqJH3jd" Name="Render Group Mask" Kind="InputPin" />
-              <Pin Id="P8Z51eA9h4iNzi81GiWrrV" Name="Edit Mode" Kind="InputPin" />
-              <Pin Id="L8REcCUEZQnP3ZD4ipn1Uu" Name="Model Effect Name" Kind="InputPin" />
-              <Pin Id="VuZWDX7baNFNPRBURwVA4O" Name="Additional Scene Renderers" Kind="InputPin" />
-              <Pin Id="UobblJaqRlcQUCF03Rikk7" Name="MSAALevel" Kind="InputPin" />
-              <Pin Id="EP6auAs9KkRMJGUQhavNQl" Name="MSAAResolver" Kind="InputPin" />
-              <Pin Id="Iq4y5AJlgllNimGTlRHddD" Name="Light Shafts" Kind="InputPin" />
-              <Pin Id="UWCXcGHmwa9LfpEAuHuoCF" Name="VR Settings" Kind="InputPin" />
-              <Pin Id="TYfqmbLbtXML95w4BYmbFU" Name="Viewport Settings" Kind="InputPin" />
-              <Pin Id="QRl7mJCPLKgLhYb2HQzfOv" Name="Subsurface Scattering Blur Settings" Kind="InputPin" />
-              <Pin Id="BGBRBslBypDNmFc2LAQzMG" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" />
-              <Pin Id="VnGORRajrYgMg1t5SmjZfG" Name="Output" Kind="OutputPin" />
-              <Pin Id="NBKaQw5bZl6N9LIvylGDX4" Name="Compositor" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="CGYyN8go59ZMc1hQyTp9u6" Bounds="458,135" />
-            <ControlPoint Id="OY9UIJxCeH3NIP6N2LXG01" Bounds="394,69" />
-            <ControlPoint Id="HDcEQI8IWi5Labf5DYKRpM" Bounds="613,473" />
-            <ControlPoint Id="UkC4OhF0X09P1BovOnjqnK" Bounds="638,495" />
-            <ControlPoint Id="AMQjUoomCzWNv9Ywf3Fwr2" Bounds="415,97" />
-            <ControlPoint Id="V8atKxY3KauOYspYzG1ZIc" Bounds="436,118" />
-            <ControlPoint Id="ETYC7IC8b5VQKaWv7kRTcx" Bounds="496,198" />
-            <ControlPoint Id="CfQkmMofpEgPxzymHoqGK2" Bounds="477,157" />
-            <Pad Id="TsIH4dW8lBSMLTMhHnSYJs" Bounds="646,515,119,25" ShowValueBox="true" isIOBox="true" Value="Clear and RenderView setup are done via Compositor">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">5</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-            <ControlPoint Id="M1H2Xy3LnQ5PLVJZEB9kO6" Bounds="778,505" />
-            <ControlPoint Id="AKPNiCjVlF1NtVkYpnYVk1" Bounds="535,273" />
-            <ControlPoint Id="PFUktaVC7hdLFhb1mXRUho" Bounds="893,232" />
-            <ControlPoint Id="Jyu0XHMsgzyPayZ3iBEtJq" Bounds="913,257" />
-            <ControlPoint Id="QlfL2g0pKEoP8t9Ge7GmNY" Bounds="859,191" />
-            <ControlPoint Id="MBwHYLN6QglN1caMdTi1Sm" Bounds="879,210" />
-            <ControlPoint Id="CKVlNYHdsmeOZTCYkOyKFA" Bounds="959,328" />
-            <ControlPoint Id="FgO0UOE7tH8NDSEhOHiG1I" Bounds="940,308" />
-            <ControlPoint Id="CSxQ0M5fmruMZquDzUbiyV" Bounds="924,282" />
-            <ControlPoint Id="DUb1yZZNgDBL25VGkCbTIt" Bounds="579,368" />
-            <ControlPoint Id="IHOtRLsvtk5OJ78JiJX81r" Bounds="554,299" />
-            <ControlPoint Id="TlA6pKJz6edO3iHDOmf7KO" Bounds="518,233" />
-            <ControlPoint Id="CmA4ANEvQcRLBSg5OWLBQB" Bounds="836,600" />
-            <Pad Id="FCtgJzP4WQAOSA2nYTGSZp" Bounds="901,598,163,64" ShowValueBox="true" isIOBox="true" Value="&lt;-Very small change just to add Compositor output">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
-          </Canvas>
-          <Link Id="MWeTomR73nIMs5fmSESk3P" Ids="BG0RTV7wEaiOc37WEontCg,QS7rNyyn0EaMm0paX6MHSW" IsHidden="true" />
-          <Link Id="KDfpi9ZyBkpLLNvBUBrbeU" Ids="UG2avpNtmXPMYVguZNOqCg,AMe2sritS0IMBbGPKbtOsR" IsHidden="true" />
-          <Link Id="Ax9IA38IrpUNFKq2HdntpU" Ids="LpwoVVG26pfOr3Ftv8fH8q,BG0RTV7wEaiOc37WEontCg" />
-          <Link Id="E4nxcEUk4qbLn48juH4gU5" Ids="PTxdFTSFUPFNynXPr8xll4,O8cjJLqGOmFNEXKJzYFTQ6" />
-          <Link Id="PQKMlWU8nscOAfJ70nlkEj" Ids="O8cjJLqGOmFNEXKJzYFTQ6,RjLkObu5B1uM0KfUTo1PDg" IsHidden="true" />
-          <Link Id="EeAUvciwwjzPnVfDoQlkXE" Ids="CGYyN8go59ZMc1hQyTp9u6,M3LxE8v3LtDPuN52eL7LiF" />
-          <Link Id="LxQp3LFbqV0QHSgNVi0rup" Ids="FXBx7fkNiCRLU0P2xJKqhu,CGYyN8go59ZMc1hQyTp9u6" IsHidden="true" />
-          <Link Id="NW4I53A7SB2PxyNmR9swHI" Ids="OY9UIJxCeH3NIP6N2LXG01,Bx3ZVyKElXoNWQVcKaObAf" />
-          <Link Id="R67sLBqW59OMcEYiSvGmO7" Ids="EtbVvgHzuvROWseLlbRI7t,OY9UIJxCeH3NIP6N2LXG01" IsHidden="true" />
-          <Link Id="ERoinwoxRyzMql3eOxH3ve" Ids="VnGORRajrYgMg1t5SmjZfG,SkvdbFcPP6bLoM7QG9i7SR" />
-          <Link Id="KoCniPE4NWiMtE1VbpX4hP" Ids="HDcEQI8IWi5Labf5DYKRpM,H5kzVMJVBVKL5qo1jFS2NT" />
-          <Link Id="O5CcEJfCsw2NXoDHWGlNNB" Ids="GVtarpFwKLKMUYn25y3shJ,HDcEQI8IWi5Labf5DYKRpM" IsHidden="true" />
-          <Link Id="DjmoS7DPLFULgtHhsesNqj" Ids="UkC4OhF0X09P1BovOnjqnK,IUPrObbY0cdLo8jsbjtV43" />
-          <Link Id="Js7Jq0VEl56OCmlclOS5nN" Ids="TJByA46cusjMkWcb2QS3t4,UkC4OhF0X09P1BovOnjqnK" IsHidden="true" />
-          <Link Id="EEUG2QzqDULNs9ttenEzIL" Ids="AMe2sritS0IMBbGPKbtOsR,FJKJg3uQMxzPV0TPIj8q90" />
-          <Link Id="J55isBdw5ZtMJ03SrvJkbV" Ids="AMQjUoomCzWNv9Ywf3Fwr2,Mz4zV97QbOrOS3Xk0cHNmU" />
-          <Link Id="DLVom3dioBCM0jD9BdfTPo" Ids="BP60hSf2rN5PPG5z0e0BGZ,AMQjUoomCzWNv9Ywf3Fwr2" IsHidden="true" />
-          <Link Id="BbNBQk90Z8zLZ44A6B7z0x" Ids="V8atKxY3KauOYspYzG1ZIc,QG7gjpORBFdMvm2SNstirl" />
-          <Link Id="ESPnLrhZZ0dL8tKA35tEMi" Ids="SMcGcsW1Gg0NZQhB8Gm0iq,V8atKxY3KauOYspYzG1ZIc" IsHidden="true" />
-          <Link Id="NJkq5XZBz4JPNHDrQA6KaX" Ids="ETYC7IC8b5VQKaWv7kRTcx,OU1hev0RQA1Nq9XWqJH3jd" />
-          <Link Id="Fk6U6TR88MlOkbdIvHjCgP" Ids="FkvGTG1wSROMz6qNHVZFIJ,ETYC7IC8b5VQKaWv7kRTcx" IsHidden="true" />
-          <Link Id="Vx8XVDUMoiyLxFzn7bXDEm" Ids="CfQkmMofpEgPxzymHoqGK2,AdWTImOBUvAPjFJG9P8UXa" />
-          <Link Id="By01GfGfjhyOMzqVfMylyK" Ids="JzFvODb1M3ZL4kbBnzz15F,CfQkmMofpEgPxzymHoqGK2" IsHidden="true" />
-          <Link Id="FDMYdwuG57rPDvJ4oI9okE" Ids="M1H2Xy3LnQ5PLVJZEB9kO6,T7MHqpk1NnwNiMzHL8YEUY" />
-          <Link Id="UFf9Etjk0nWPQEQHeNeuEm" Ids="GpGzIPJ3sIyMv5iUUzz6fb,M1H2Xy3LnQ5PLVJZEB9kO6" IsHidden="true" />
-          <Link Id="CVFuhDrMsFtO7YiD7yXqex" Ids="KD6qN4D3gEVMAwE8e41Lsf,AKPNiCjVlF1NtVkYpnYVk1" IsHidden="true" />
-          <Link Id="D7UXbkjYgGjOMiddD4vGm1" Ids="AKPNiCjVlF1NtVkYpnYVk1,L8REcCUEZQnP3ZD4ipn1Uu" />
-          <Link Id="ERoJYzh9FYYPxKnYOJEOsb" Ids="LVjLNbRSgcfOB7Lm12o44G,PFUktaVC7hdLFhb1mXRUho" IsHidden="true" />
-          <Link Id="NAR0AfeesvrP9pxCcVTMtH" Ids="CQ5tHg5NY71LYxV1LwMYK2,Jyu0XHMsgzyPayZ3iBEtJq" IsHidden="true" />
-          <Link Id="KNuY5NAtzeBP358Gtl2M3h" Ids="KwoZs43lDWiOrMmAZ2GSPC,QlfL2g0pKEoP8t9Ge7GmNY" IsHidden="true" />
-          <Link Id="RGgrDuBQkTJMR0EUmaN1Uw" Ids="SY50l8NcjMjPHEi2nqN1Ap,MBwHYLN6QglN1caMdTi1Sm" IsHidden="true" />
-          <Link Id="Vi0aIM3EKuwLtvdktlnrSe" Ids="B7qJAskl6Z7ODVPD6fXj5B,CKVlNYHdsmeOZTCYkOyKFA" IsHidden="true" />
-          <Link Id="DRUnx6BikmINPtBASQns1R" Ids="TvHuh15oTAHQGUgQePZLpa,FgO0UOE7tH8NDSEhOHiG1I" IsHidden="true" />
-          <Link Id="MCKiHKUYecAPFZqgGGlof0" Ids="QlfL2g0pKEoP8t9Ge7GmNY,UobblJaqRlcQUCF03Rikk7" />
-          <Link Id="DLHt0MC5GcPPlPPL9UGCwq" Ids="MBwHYLN6QglN1caMdTi1Sm,EP6auAs9KkRMJGUQhavNQl" />
-          <Link Id="K9AFItvaoLBNxyYtAwBBfZ" Ids="PFUktaVC7hdLFhb1mXRUho,Iq4y5AJlgllNimGTlRHddD" />
-          <Link Id="OKLZK2VYr5CNnjR9PuqezI" Ids="FgO0UOE7tH8NDSEhOHiG1I,QRl7mJCPLKgLhYb2HQzfOv" />
-          <Link Id="D60fFDm3BVfMc9JlGpgRjY" Ids="CKVlNYHdsmeOZTCYkOyKFA,BGBRBslBypDNmFc2LAQzMG" />
-          <Link Id="A9KvJS1ZDVcOwB6QYh6cCa" Ids="Jyu0XHMsgzyPayZ3iBEtJq,UWCXcGHmwa9LfpEAuHuoCF" />
-          <Link Id="F8Y74pR8xMPMJ0IGUSjqgP" Ids="VDsH3cnfnWaLnL24giUBGE,CSxQ0M5fmruMZquDzUbiyV" IsHidden="true" />
-          <Link Id="Mf8kw3dduvhMzqNaBL7Aee" Ids="CSxQ0M5fmruMZquDzUbiyV,TYfqmbLbtXML95w4BYmbFU" />
-          <ProcessDefinition Id="NWDfrQm47ziOShyfcQ5bac">
-            <Fragment Id="Qv4d5ccw9HcPDjgbLjrnFb" Patch="PEJQYHvthdSN0QUCFNtnFJ" Enabled="true" />
-            <Fragment Id="Pgo1KJRGQFUOMYsC8QYIx6" Patch="N0W0KwgPMY9LU1QP2Qk59W" Enabled="true" />
-            <Fragment Id="ETWjVknihuDQGvOZhRCNLl" Patch="AQNCGu3E8qePSXdosZHyxM" Enabled="true" />
-            <Fragment Id="RqpItinP5evPiqelrKAeod" Patch="NghODkkgDLTONRHZAbIHZn" Enabled="true" />
-            <Fragment Id="HRNfE22gT5MP2Rp0D2FZww" Patch="OzfMXKnCAzUM6ahQn7YTEQ" Enabled="true" />
-            <Fragment Id="C9h1ZPP4pOwLxuuJZZgSBA" Patch="R09ZLoZbOpmLMT8sq7Ubg8" Enabled="true" />
-            <Fragment Id="KrEsgQyAGMhLvghH02WPrV" Patch="K1LFctdXOMpQcHp5KoySaV" Enabled="true" />
-            <Fragment Id="LkqAFASRZtsPJgTtQb1a5f" Patch="JSsRlYrHknOOu8b5EwMBBc" Enabled="true" />
-          </ProcessDefinition>
-          <Link Id="UuUetGcCElKNimdCSFxT9W" Ids="DUb1yZZNgDBL25VGkCbTIt,Mdbe9ryhQMlPBQXElzMVmI" />
-          <Link Id="UrkDC7V4P5INJHlzkjZcLe" Ids="KTb19ZfWV2GMJJ4NmiFTDV,DUb1yZZNgDBL25VGkCbTIt" IsHidden="true" />
-          <Link Id="FTlpMmxDgU9OvTdYIR1OyM" Ids="IHOtRLsvtk5OJ78JiJX81r,VuZWDX7baNFNPRBURwVA4O" />
-          <Link Id="Fwh0Zt6wm1VN7FI9qV7B3L" Ids="ImIB92ypK7AQK8HDvO6LBT,IHOtRLsvtk5OJ78JiJX81r" IsHidden="true" />
-          <Link Id="S0RzwKB3XurN6clU0NpHtZ" Ids="TlA6pKJz6edO3iHDOmf7KO,P8Z51eA9h4iNzi81GiWrrV" />
-          <Link Id="MHA1eCtB3DmO65Wfuk73Tm" Ids="JjOc7b9RO7hPjIYYrK48Zj,TlA6pKJz6edO3iHDOmf7KO" IsHidden="true" />
-          <Link Id="BWMcQkrKx0HQMxO9fyPi7b" Ids="NBKaQw5bZl6N9LIvylGDX4,CmA4ANEvQcRLBSg5OWLBQB" />
-          <Link Id="VyQGWBjJOXwP0pwOxop0LA" Ids="CmA4ANEvQcRLBSg5OWLBQB,P0ibDPaCatKPAxvW3d3vMF" IsHidden="true" />
-          <Patch Id="PEJQYHvthdSN0QUCFNtnFJ" Name="Create" />
-          <Patch Id="N0W0KwgPMY9LU1QP2Qk59W" Name="Update" ManuallySortedPins="true">
-            <Pin Id="UG2avpNtmXPMYVguZNOqCg" Name="Input" Kind="InputPin" Bounds="681,340" />
-            <Pin Id="KTb19ZfWV2GMJJ4NmiFTDV" Name="Size" Kind="InputPin" Bounds="579,366" />
-            <Pin Id="EtbVvgHzuvROWseLlbRI7t" Name="Camera" Kind="InputPin" Bounds="526,379" />
-            <Pin Id="SMcGcsW1Gg0NZQhB8Gm0iq" Name="Clear Color" Kind="InputPin" Bounds="460,415" />
-            <Pin Id="BP60hSf2rN5PPG5z0e0BGZ" Name="Clear" Kind="InputPin" Bounds="410,389" />
-            <Pin Id="FXBx7fkNiCRLU0P2xJKqhu" Name="Post Effects" Kind="InputPin" Bounds="494,342" />
-            <Pin Id="JzFvODb1M3ZL4kbBnzz15F" Name="Enable Default Post Effects" Kind="InputPin" Bounds="531,334" />
-            <Pin Id="GVtarpFwKLKMUYn25y3shJ" Name="Format" Kind="InputPin" Bounds="683,482" />
-            <Pin Id="TJByA46cusjMkWcb2QS3t4" Name="Depth Format" Kind="InputPin" Bounds="739,494" DefaultValue="D24_UNorm_S8_UInt">
-              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
-                <Choice Kind="TypeFlag" Name="PixelFormat" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="FkvGTG1wSROMz6qNHVZFIJ" Name="Render Group Mask" Kind="InputPin" Bounds="519,377" Visibility="Optional" />
-            <Pin Id="JjOc7b9RO7hPjIYYrK48Zj" Name="Edit Mode" Kind="InputPin" Bounds="518,233" Visibility="Optional" />
-            <Pin Id="KD6qN4D3gEVMAwE8e41Lsf" Name="Model Effect Name" Kind="InputPin" Bounds="870,554" Visibility="Optional" />
-            <Pin Id="ImIB92ypK7AQK8HDvO6LBT" Name="Additional Scene Renderers" Kind="InputPin" Bounds="554,299" Visibility="Optional" />
-            <Pin Id="GpGzIPJ3sIyMv5iUUzz6fb" Name="Enabled" Kind="InputPin" Bounds="745,481" />
-            <Pin Id="QS7rNyyn0EaMm0paX6MHSW" Name="Output" Kind="OutputPin" Bounds="404,481" />
-            <Pin Id="RjLkObu5B1uM0KfUTo1PDg" Name="Depth" Kind="OutputPin" Bounds="377,834" />
-            <Pin Id="P0ibDPaCatKPAxvW3d3vMF" Name="Compositor" Kind="OutputPin" Bounds="830,581" />
-          </Patch>
-          <Patch Id="NghODkkgDLTONRHZAbIHZn" Name="SetLightShafts">
-            <Pin Id="LVjLNbRSgcfOB7Lm12o44G" MergeId="33236" Name="Light Shafts" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="OzfMXKnCAzUM6ahQn7YTEQ" Name="SetVRSettings">
-            <Pin Id="CQ5tHg5NY71LYxV1LwMYK2" MergeId="33240" Name="VR Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="K1LFctdXOMpQcHp5KoySaV" Name="SetSubsurfaceScatteringBlurEffect">
-            <Pin Id="TvHuh15oTAHQGUgQePZLpa" MergeId="33246" Name="Subsurface Scattering Blur Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="AQNCGu3E8qePSXdosZHyxM" Name="SetMSAA">
-            <Pin Id="KwoZs43lDWiOrMmAZ2GSPC" MergeId="33252" Name="MSAALevel" Kind="InputPin" DefaultValue="X4" Visibility="Optional">
-              <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
-                <Choice Kind="TypeFlag" Name="MultisampleCount" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="SY50l8NcjMjPHEi2nqN1Ap" MergeId="33256" Name="MSAAResolver" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="JSsRlYrHknOOu8b5EwMBBc" Name="SetBindDepthDuringTransparentStage">
-            <Pin Id="B7qJAskl6Z7ODVPD6fXj5B" MergeId="33263" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" Visibility="Optional" />
-          </Patch>
-          <Patch Id="R09ZLoZbOpmLMT8sq7Ubg8" Name="SetViewportSettings">
-            <Pin Id="VDsH3cnfnWaLnL24giUBGE" MergeId="112917" Name="Viewport Settings" Kind="InputPin" Visibility="Optional" />
-          </Patch>
+          <Link Id="MUGDd0UAupgMgNzZb9wnd4" Ids="Hl2dW5WoWo9MuGR7kgzay8,DhzIRqeDHaRMkSCcIvzqZy" IsHidden="true" />
+          <Link Id="BxF40iB25eCPrvJ2xr9Hcw" Ids="DhzIRqeDHaRMkSCcIvzqZy,QzYFfrYiuRmP6fThRgvlKE" />
+          <Link Id="Sn0dmzNyYtjPYhMiier8Ni" Ids="UUSfYs5XCFrOQJCIzUOlWm,OkO5TLf1z7MQJq7zLO5eza" IsHidden="true" />
+          <Link Id="BBfGXL6meg9QIjsq64V96f" Ids="OkO5TLf1z7MQJq7zLO5eza,OMebjSEg2RSQWjWtQSFGYc" />
         </Patch>
       </Node>
       <Canvas Id="PLj8eotbst0K92IpLF5eNw" Name="Internal" Position="351,355">
@@ -2890,19 +789,19 @@
               </Node>
               <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="1412,1573" />
               <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="1412,1538" />
-              <Node Bounds="938,1268,413,324" Id="E2oflgh7P6CM3IqV2TYFc9">
+              <Node Bounds="920,1266,431,364" Id="E2oflgh7P6CM3IqV2TYFc9">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 </p:NodeReference>
                 <Pin Id="KxBUKEtfv0fOxAQDvjnjxZ" Name="Condition" Kind="InputPin" />
-                <ControlPoint Id="TZQ2Hot5LNzPNBSybYBMtt" Bounds="1334,1274" Alignment="Top" />
-                <ControlPoint Id="JvUSaK0Yr5UNeZ5crtundU" Bounds="1332,1586" Alignment="Bottom" />
+                <ControlPoint Id="TZQ2Hot5LNzPNBSybYBMtt" Bounds="1334,1272" Alignment="Top" />
+                <ControlPoint Id="JvUSaK0Yr5UNeZ5crtundU" Bounds="1332,1624" Alignment="Bottom" />
                 <Patch Id="NVm0f2JOHhOMbyHJUlAFrx" ManuallySortedPins="true">
                   <Patch Id="BqhqQQMgSiBQAz4lJmAZud" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="L1y86PLt1KkMUcqinp6zKl" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="950,1448,85,26" Id="AcWwmmky3c7MBjc6PXWyWd">
+                  <Node Bounds="952,1511,85,26" Id="AcWwmmky3c7MBjc6PXWyWd">
                     <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Stride" />
@@ -2914,7 +813,7 @@
                     <Pin Id="NIljp4eBBPNP2GU9WODEJ1" Name="Tag Value" Kind="InputPin" />
                     <Pin Id="QnYylTDVqZvL20CCf6OwqT" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1030,1346,117,19" Id="G6uykTFllYeNhgISZJviWo">
+                  <Node Bounds="1032,1409,117,19" Id="G6uykTFllYeNhgISZJviWo">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GetShadowParameters" />
@@ -2922,7 +821,7 @@
                     <Pin Id="Ncu9UhXBddDQJbNOYVnmcN" Name="Input" Kind="InputPin" />
                     <Pin Id="K3fuXPky3owOXIsRIqyPol" Name="Output" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="950,1515,74,26" Id="L9WJwzXE2xjLWUS36NEgVe">
+                  <Node Bounds="933,1579,74,26" Id="L9WJwzXE2xjLWUS36NEgVe">
                     <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
@@ -2932,7 +831,7 @@
                     <Pin Id="BXzovYZWWJbQX9U0z42z9v" Name="Value" Kind="InputPin" />
                     <Pin Id="IDAPygsxibALZnZ2ygil3Y" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1030,1390,94,26" Id="RAnNXOh8oUbPe3MOQO3c3C">
+                  <Node Bounds="1032,1453,94,26" Id="RAnNXOh8oUbPe3MOQO3c3C">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SetFrameNumber" />
@@ -2941,7 +840,35 @@
                     <Pin Id="M00kkHOXfOeLZnk4sJZKDQ" Name="Frame Number" Kind="InputPin" />
                     <Pin Id="QBMTr7t38mwQb0zIwpiTUc" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <ControlPoint Id="MwgFzhiXztSLQqBcYbesIA" Bounds="1248,1453" />
+                  <Node Bounds="1175,1410,72,26" Id="PtLYSVp2bx7MW1EP8PcGup">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Games.GameTime" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="FrameCount" />
+                    </p:NodeReference>
+                    <Pin Id="Rfqc1Rnr4dqP6ej8EhayuO" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="TXmlJQ0OxQUL7QupHxMoGB" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="Np8GwSBNQ4XNfyzrv4qPzv" Name="Frame Count" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1178,1371,70,26" Id="TAUep27DBp6QUbsmlvfyyB">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderContext" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="RenderContext" />
+                      <Choice Kind="OperationCallFlag" Name="Time" />
+                    </p:NodeReference>
+                    <Pin Id="QCTEskz2qO9NuGjaetErWB" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="CGEXnBUpvSTLS0axG69htX" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="UchoJ0s2gQQMUELnHoG1qT" Name="Time" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="932,1306,88,26" Id="AbEEWBDB5s4L93QKTpBgyD">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderDrawContext" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="RenderDrawContext" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="RenderContext" />
+                    </p:NodeReference>
+                    <Pin Id="Q0bmANwraT8Lfhy4duHxsV" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="PYh3h15jRWSLHPzUjPSJ5w" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="TKHYqMMdQqEPqGNCoTpZ7y" Name="Render Context" Kind="OutputPin" />
+                  </Node>
                 </Patch>
               </Node>
               <Node Bounds="887,675,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
@@ -2977,8 +904,6 @@
                 <Pin Id="C1JV9EANnLvLpeklUutEFA" Name="Result" Kind="OutputPin" />
                 <Pin Id="AKyDxhhOVjzMMKRZv0Shny" Name="Value" Kind="OutputPin" />
               </Node>
-              <Pad Id="S78rsCgoGA1LtdGfKVYSJJ" SlotId="TCuBmbFlbQ6PEmI1LLzLY6" Bounds="1124,1217" />
-              <ControlPoint Id="PERgaE6IPCxNcvWx4SVk8R" Bounds="1124,1168" />
               <Node Bounds="993,675,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -3006,8 +931,6 @@
                 <ControlPoint Id="IxqQrHJ91xJQcaGAqAQAz6" Bounds="1333,1047" Alignment="Bottom" />
                 <ControlPoint Id="RaIamlQu0lVLjqhiC6KrW7" Bounds="1126,1047" Alignment="Bottom" />
                 <ControlPoint Id="IpMSLzGgPVwMZPbBGA5blz" Bounds="1080,841" Alignment="Top" />
-                <ControlPoint Id="NPg02mKQCehNQ1a9y7Go7f" Bounds="1235,1047" Alignment="Bottom" />
-                <ControlPoint Id="FwKbctbVBqqP2h7ScbH3Fy" Bounds="1235,841" Alignment="Top" />
                 <Patch Id="JW5nSNNltKbPmj6VGFtiLm" ManuallySortedPins="true">
                   <Patch Id="OHmUd0hSRDRNpStjU5d3rx" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="LCnz1ntY4nLPdeDSl0GBdQ" Name="Then" ManuallySortedPins="true" />
@@ -3069,7 +992,6 @@
                 <Pin Id="S8rWG1pCqqQNsVYCIC6B7N" Name="Input" Kind="StateInputPin" />
                 <Pin Id="Umg2Y0jf8fWPOZqbguB6SW" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="UEheoMmBhpEMxSMPuG80Ct" Bounds="1233,1371" />
               <Pad Id="O6QzbilCiKMM6Tdt3FxdcR" Bounds="1153,743,98,19" ShowValueBox="true" isIOBox="true" Value="Check if exists">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
@@ -3106,13 +1028,13 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
+              <ControlPoint Id="PNKzeQzu1fvLkd6tTKFAWN" Bounds="924,1152" />
             </Canvas>
             <Patch Id="PYcVQQWp6PkPYTo8m9u9KV" Name="Create" />
             <ProcessDefinition Id="BsrycrTeJZ2QSp24BsEq5E" HasStateOut="true">
               <Fragment Id="EMshQ1QdD2uL1U2wp2SAAN" Patch="PYcVQQWp6PkPYTo8m9u9KV" Enabled="true" />
               <Fragment Id="Q4I6up1cThnMezlHoJXPCp" Patch="A7yxmq7xlgROzf9OCaTbx6" />
               <Fragment Id="HEADEpqPcFeMfKsd7XOLwo" Patch="NVWQ07a49cROHCLR8dmmz5" Enabled="true" />
-              <Fragment Id="AkiLcxNEFAgOO7OCAnuqRV" Patch="OEB3dBZF9mXL28hxAJgn0c" Enabled="true" />
             </ProcessDefinition>
             <Patch Id="A7yxmq7xlgROzf9OCaTbx6" Name="Draw">
               <Pin Id="ThISyoqzkA2LqxFH7SJgKD" MergeId="45458" Name="Context" Kind="InputPin" />
@@ -3126,14 +1048,7 @@
             <Link Id="TkPJQgtcADdOVh3NJPU8Wq" Ids="NLHRb9iLlutO0V1rXdc3B2,K5oNmlJ0fOSMp4V5bX6uiJ" IsHidden="true" />
             <Link Id="OyMlH18CTwQO16tWsJV4XN" Ids="C8x51fcLrN1OS8lL4g9LJ5,Q1oJb8MLljLOQ6mgA1aVGD" />
             <Link Id="ULMxDEjPceePrWUJoRNI4D" Ids="EDRuTOkzYh6PRNnmbXMt0l,UeAxhYBk6PJNIKrLmNoWkc" />
-            <Slot Id="TCuBmbFlbQ6PEmI1LLzLY6" Name="Compositor" />
-            <Link Id="L9EtnIbTKkXMbnQcPmWhx4" Ids="S78rsCgoGA1LtdGfKVYSJJ,Ncu9UhXBddDQJbNOYVnmcN" />
-            <Link Id="BouM5LQTWXTL7SBMFOSDSC" Ids="PERgaE6IPCxNcvWx4SVk8R,S78rsCgoGA1LtdGfKVYSJJ" />
-            <Link Id="TdiD8Ae7yxXNcwDdoW9KX1" Ids="Qy3ohbILJQ8M3zGxlXFWIO,PERgaE6IPCxNcvWx4SVk8R" IsHidden="true" />
             <Link Id="PqRFATsehsnLps6mqtpBiW" Ids="FqV2QIIT2vsLlmwb3dzckZ,I7addska4f1OEFHYa3Gapr" />
-            <Patch Id="OEB3dBZF9mXL28hxAJgn0c" Name="SetCompositor">
-              <Pin Id="Qy3ohbILJQ8M3zGxlXFWIO" Name="Compositor" Kind="InputPin" />
-            </Patch>
             <Link Id="HfGqiQYTX3xMEsjHkKwEnT" Ids="Nx6K7kWkA87OtTB6bRmS1k,OiLBoODHrowOqNBXuizUrE" />
             <Link Id="Apl09VJ6oFNMUwT98xudTM" Ids="TZQ2Hot5LNzPNBSybYBMtt,JvUSaK0Yr5UNeZ5crtundU" IsFeedback="true" />
             <Link Id="ACJAvot9ZmMNjhzWFGmtAT" Ids="TZQ2Hot5LNzPNBSybYBMtt,JvUSaK0Yr5UNeZ5crtundU" />
@@ -3150,20 +1065,22 @@
             <Link Id="LUR0xxpsEcZNFlxy0ElNef" Ids="AKyDxhhOVjzMMKRZv0Shny,JGOurSWOXWvPy1OAIL4HmX" />
             <Link Id="A6PyY6lbChFMhoZ5wP1tcT" Ids="IpMSLzGgPVwMZPbBGA5blz,RaIamlQu0lVLjqhiC6KrW7" IsFeedback="true" />
             <Link Id="JYWUgX8ZIQwLFd8JlrdAlz" Ids="J4npV9lSvbgOU4S454mdLs,RaIamlQu0lVLjqhiC6KrW7" />
-            <Link Id="VkjUUUzV0zWOZ2qtPeVRL4" Ids="RaIamlQu0lVLjqhiC6KrW7,KxBUKEtfv0fOxAQDvjnjxZ" />
+            <Link Id="VkjUUUzV0zWOZ2qtPeVRL4" Ids="RaIamlQu0lVLjqhiC6KrW7,PNKzeQzu1fvLkd6tTKFAWN,KxBUKEtfv0fOxAQDvjnjxZ" />
             <Link Id="JCWB4ghJmzNLKRJJIrApF0" Ids="LhGIJcBZxWiPc1YkWayura,IxqQrHJ91xJQcaGAqAQAz6" />
             <Link Id="HjkKMQLKwVWLJQnVKF2foM" Ids="IxqQrHJ91xJQcaGAqAQAz6,TZQ2Hot5LNzPNBSybYBMtt" />
             <Link Id="SRsvCORpANTNAbNuMNVz4T" Ids="K3fuXPky3owOXIsRIqyPol,TC03cat8lzlM4YFcqgsVdJ" />
             <Link Id="PcUki57oSl5PffPeGZwGn9" Ids="QBMTr7t38mwQb0zIwpiTUc,NIljp4eBBPNP2GU9WODEJ1" />
             <Link Id="RhgM81wgd7jNV8MyXpjGts" Ids="C1JV9EANnLvLpeklUutEFA,S8rWG1pCqqQNsVYCIC6B7N" />
             <Link Id="UIzCHjNzZqjNmcub4aC3jB" Ids="Umg2Y0jf8fWPOZqbguB6SW,IpMSLzGgPVwMZPbBGA5blz" />
-            <Link Id="N7o4dKp4MFTPke3gPkNF0F" Ids="FwKbctbVBqqP2h7ScbH3Fy,NPg02mKQCehNQ1a9y7Go7f" IsFeedback="true" />
-            <Link Id="AolXBksIxTvLwLNyKdA8dl" Ids="TZQ2Hot5LNzPNBSybYBMtt,MwgFzhiXztSLQqBcYbesIA,MAjVz8F1ql9QDHa5ZxitCk" />
-            <Link Id="Hjm3NBljt4wNiP0gAzG6t9" Ids="Ens0hr7dX2rMlNsAfW0seh,NPg02mKQCehNQ1a9y7Go7f" />
             <Link Id="GQbiZp4BvxUL9kflmcUoeW" Ids="RsvPWzAxI17MJMevV3n0PD,OONBzYIWg0eNEX1CJG31jd" />
             <Link Id="QXhsLCt9avZNaGJMwLx2p4" Ids="Ens0hr7dX2rMlNsAfW0seh,UWQqR8NgAkHPUBP9liAwMg" />
             <Link Id="SASFtIuQWYCPxnr72vAd6v" Ids="J99x0MKAcmEPQEHl84ofJQ,EPlb5vrWJZ8P5VtmajBQ27" />
-            <Link Id="GybzmbD4ufDMmrqFjCRvBj" Ids="NPg02mKQCehNQ1a9y7Go7f,UEheoMmBhpEMxSMPuG80Ct,M00kkHOXfOeLZnk4sJZKDQ" />
+            <Link Id="NhyUNU2LsHXP2hWWzAJK7X" Ids="UchoJ0s2gQQMUELnHoG1qT,Rfqc1Rnr4dqP6ej8EhayuO" />
+            <Link Id="EusVkRmpC02NYwdTdXiHa2" Ids="TKHYqMMdQqEPqGNCoTpZ7y,QCTEskz2qO9NuGjaetErWB" />
+            <Link Id="GzvZEb78FFRPMnjo2AqGxR" Ids="TZQ2Hot5LNzPNBSybYBMtt,Q0bmANwraT8Lfhy4duHxsV" />
+            <Link Id="FwwGAKynfuANN6toyDtorc" Ids="PYh3h15jRWSLHPzUjPSJ5w,MAjVz8F1ql9QDHa5ZxitCk" />
+            <Link Id="Pw8YIfUi5MoOZzfG6Ssxb5" Ids="TKHYqMMdQqEPqGNCoTpZ7y,Ncu9UhXBddDQJbNOYVnmcN" />
+            <Link Id="TRSoje0QogjMDlQJtIMseu" Ids="Np8GwSBNQ4XNfyzrv4qPzv,M00kkHOXfOeLZnk4sJZKDQ" />
           </Patch>
         </Node>
         <!--
@@ -3248,6 +1165,1263 @@
             <Link Id="QDfKYZsdS7AMALfh0h4pvn" Ids="Q4eBN3bvGyAPdjI8vvpnNp,GaCJG6S4VPtLN9sUjtLCNl" />
           </Patch>
         </Node>
+        <!--
+
+    ************************ GetShadowParameters ************************
+
+-->
+        <Node Name="GetShadowParameters" Bounds="523,626" Id="RZILdx8O0jTNRFrS7mfDJp">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="SON3CEI2kBjLcG3NfNpv7G">
+            <Canvas Id="EgSisUc61tjPzdiFhVaBwS" CanvasType="Group">
+              <ControlPoint Id="I0g2MNpsm6ZNFifBoRUF0z" Bounds="445,254" />
+              <Node Bounds="268,423,948,1292" Id="TyPSp8TtaR0PQhT8hVqfUk">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="SQtbV1jbCPrPdAp7KWD7n8" Name="Condition" Kind="InputPin" />
+                <ControlPoint Id="RU3goxYONyANponSD1eDzU" Bounds="634,1709" Alignment="Bottom" />
+                <ControlPoint Id="Iy4HwBwEqSBOsyBvKOfRb4" Bounds="630,429" Alignment="Top" />
+                <ControlPoint Id="I5UtU51hlIgM1UYfYKyLhg" Bounds="716,1709" Alignment="Bottom" />
+                <ControlPoint Id="ED2oz49Ck2oQMP3fVCoV0L" Bounds="712,429" Alignment="Top" />
+                <ControlPoint Id="PHYK54lLvFbM6pUnBFTVfS" Bounds="812,1709" Alignment="Bottom" />
+                <ControlPoint Id="E8uu2M5bGCAPjOTfAwTqGI" Bounds="792,429" Alignment="Top" />
+                <ControlPoint Id="GhcjcUpVOyEQSZajxj5ww5" Bounds="463,1709" Alignment="Bottom" />
+                <ControlPoint Id="A5Bv3SGvncCOLMCWTpd3og" Bounds="479,429" Alignment="Top" />
+                <ControlPoint Id="T8BgaExhL2GN6IIVTNyMTn" Bounds="941,1709" Alignment="Bottom" />
+                <ControlPoint Id="TejA9u6u4PPOZXbqaXih2k" Bounds="961,429" Alignment="Top" />
+                <ControlPoint Id="K4K1Le5vhAvQST7AwDJY2n" Bounds="1077,1709" Alignment="Bottom" />
+                <ControlPoint Id="UV0Gkn4qLHSNdqCPalzTS0" Bounds="1062,429" Alignment="Top" />
+                <ControlPoint Id="EzH6I7or5joMvrXL9qZqM7" Bounds="1151,1709" Alignment="Bottom" />
+                <ControlPoint Id="Hq2tV2m2Ud6QGZZiQqvap6" Bounds="1142,429" Alignment="Top" />
+                <Patch Id="PaSeR6tD6n6Nuwz6omHMXO" ManuallySortedPins="true">
+                  <Patch Id="OO1DHujRviiLvMzNe77vm7" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="C2wtV0PIZpMOUf6Pr7GbqY" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="438,514,87,26" Id="L7jEKVYo3qnLVdl16N6s6I">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.RenderSystem" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="RenderSystem" />
+                      <Choice Kind="OperationCallFlag" Name="RenderFeatures" />
+                    </p:NodeReference>
+                    <Pin Id="Cz0S2CnsCgrPgFQf3E6FLm" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="VgEwi218AEkLz2FZvYPBxY" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="LfLT1P6GjFuP0a7GtkjEFX" Name="Render Features" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="604,549,87,26" Id="L6LAslSxZxJMNMHvpjPAVZ">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshRenderFeature" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="MeshRenderFeature" />
+                      <Choice Kind="OperationCallFlag" Name="Create" />
+                    </p:NodeReference>
+                    <Pin Id="EWzQnfakDs7PKqpXxDhoow" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="478,604,80,19" Id="K3o7mKuK0NHLW9amb3yCbd">
+                    <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
+                    </p:NodeReference>
+                    <Pin Id="M1isOSM0499MJy3RzHUBZo" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Dz7HnNgWTlQOMOSyS5K1dh" Name="Default Value" Kind="InputPin" />
+                    <Pin Id="PGhxcScKaZgNgftp9ypnf3" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="SkjzjFsJIANNcsQpHMU9CG" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="492,648,87,26" Id="UrvDo6xwIR0QORRxGvydXD">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.MeshRenderFeature" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="MeshRenderFeature" />
+                      <Choice Kind="OperationCallFlag" Name="RenderFeatures" />
+                    </p:NodeReference>
+                    <Pin Id="Mz7doCkSwntNLfrrDbW4Q5" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="S88l1DkLuNoMrE1j5JcQNj" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="L3cHNgrsAyUNCxrMD09MU1" Name="Render Features" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="526,740,80,19" Id="ChtZu8NAii2OETtD6JMPj1">
+                    <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
+                    </p:NodeReference>
+                    <Pin Id="MBv7nUQzuzUMqMWz0PJqHU" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="P1SOwe1xHIwOLPFh8grrXQ" Name="Default Value" Kind="InputPin" />
+                    <Pin Id="S003PqaZgxLOyuBRpLJdT8" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="F5s9wSV55O2L9IY6cwOWHj" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="616,691,126,26" Id="FzQTGyaYPOFNl3lH9LKdy9">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.ForwardLightingRenderFeature" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Create" />
+                    </p:NodeReference>
+                    <Pin Id="H5qi1XPy98ILyM8UWQVTbX" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="537,701,49,19" Id="E8FmHW68w40P5v9RDRFxlT">
+                    <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="OfType" />
+                    </p:NodeReference>
+                    <Pin Id="O9rhKVSqEMdNSKWhZW5nOx" Name="Input" Kind="InputPin" />
+                    <Pin Id="JmJerhqYOrjMMu0purFbnL" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="503,562,49,19" Id="AVNQITFHbAnPvwUjInSTz7">
+                    <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="OfType" />
+                    </p:NodeReference>
+                    <Pin Id="SBzctdViuHDPFazil2mOwV" Name="Input" Kind="InputPin" />
+                    <Pin Id="TshbPAps052P2fT4Dcc8qu" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="566,786,126,26" Id="TLILiWDGtRxNMST3j8yVYJ">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.ForwardLightingRenderFeature" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ForwardLightingRenderFeature" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="ShadowMapRenderer" />
+                    </p:NodeReference>
+                    <Pin Id="TSPjclY1HOKL30NCIfYsw8" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="LFGR1i50iiVNi0iWM5PrER" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="Qlx0drSEHV8LBqr15sHagk" Name="Shadow Map Renderer" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="653,841,48,19" Id="Ur7AC1yHTJANkprbQbhof4">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="CastAs" />
+                    </p:NodeReference>
+                    <Pin Id="QK4bKFpKXaALRAXgtkTTJI" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="UMkauxr1MG0MefK59oEOgI" Name="Default" Kind="InputPin" />
+                    <Pin Id="PggSSliOLndLnBwRZkYoe9" Name="Result" Kind="OutputPin" />
+                    <Pin Id="Q8ZIj5ksF8uN9u6TcGoxzf" Name="Success" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="721,792,111,19" Id="EIUCOUOZwF0QWzNWlfEfpl">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadow" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Shadow" NeedsToBeDirectParent="true" />
+                      <Choice Kind="ProcessAppFlag" Name="ShadowMapRenderer" />
+                    </p:NodeReference>
+                    <Pin Id="TEyR0hMp44DPqoyD9JT6Tr" Name="Renderers" Kind="InputPin" />
+                    <Pin Id="R22Ehl4Kax5LkO9s72Hx1v" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="654,874,91,19" Id="IbDrxsFavX6M8BaUQxWBvH">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="GetShadowMaps" />
+                    </p:NodeReference>
+                    <Pin Id="JCldUWGOvcPMmN0594EQAX" Name="Feature" Kind="InputPin" />
+                    <Pin Id="TRRI1whBMgILZsekpYV0lp" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="487,869,80,19" Id="CdaUuPeA6DlMxkgxygP56H">
+                    <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
+                    </p:NodeReference>
+                    <Pin Id="Qav7LB4JA1gON5PT3SyeNR" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FnZXjCDPcuCQYdODMnMMTo" Name="Default Value" Kind="InputPin" />
+                    <Pin Id="QnkBbOy1jHPMRUPUfPChf0" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="KoL14pEnY79NaPwRYbLU8y" Name="Result" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1051,858,50,26" Id="DgpjWIT3jNlMD9XgPrgu2K">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightSpot" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="LightSpot" />
+                      <Choice Kind="OperationCallFlag" Name="Create" />
+                    </p:NodeReference>
+                    <Pin Id="BKmQRPOsyGlLvnQNG1EqDv" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="291,943,913,729" Id="MdzYDq4flXdMGnGEQhwnB5">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    </p:NodeReference>
+                    <Pin Id="LqIYuL5CQaeN9iARmn2USm" Name="Condition" Kind="InputPin" />
+                    <ControlPoint Id="HyA9KfBu6CmPhSd8nXvF0T" Bounds="472,1666" Alignment="Bottom" />
+                    <ControlPoint Id="VJloK0ficxcLXIiZseXR3H" Bounds="498,949" Alignment="Top" />
+                    <ControlPoint Id="DrE4D719LJjL5u0z8iS9wV" Bounds="626,1666" Alignment="Bottom" />
+                    <ControlPoint Id="CLvx9DeLSZQMiYuRGU8YqK" Bounds="621,949" Alignment="Top" />
+                    <ControlPoint Id="OEDJj0DhTEZOQtz2Ltvqcr" Bounds="722,1666" Alignment="Bottom" />
+                    <ControlPoint Id="JrCMgumaXpoMWnhrZazwQP" Bounds="717,949" Alignment="Top" />
+                    <ControlPoint Id="BX7i6c2g9cpOB8PUivn9hy" Bounds="806,1666" Alignment="Bottom" />
+                    <ControlPoint Id="NDO6NknCKEPO4AQ23v2Eqk" Bounds="778,949" Alignment="Top" />
+                    <ControlPoint Id="BWZnOtWow1rLpJqgcbOWVr" Bounds="934,1666" Alignment="Bottom" />
+                    <ControlPoint Id="I9NdXs5bam3M3RgaGq3Ipd" Bounds="963,949" Alignment="Top" />
+                    <ControlPoint Id="V4Ih6a8LuFxNylplV73xF2" Bounds="1076,1666" Alignment="Bottom" />
+                    <ControlPoint Id="R8EsaKJZNpkQXsAcROtckE" Bounds="1061,949" Alignment="Top" />
+                    <ControlPoint Id="BK1KdjsPjvvOdoQ4kAIFmv" Bounds="1153,1666" Alignment="Bottom" />
+                    <ControlPoint Id="Ch3xmWAQACNOawikQwl45v" Bounds="1144,949" Alignment="Top" />
+                    <Patch Id="CZWtelcI38APQr8s0bA4Ww" ManuallySortedPins="true">
+                      <Patch Id="Uuqk1eIi6F7Pf5UM6g0vIV" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="S65zP6uvnypMi4XPWiUDdM" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="307,1254,104,26" Id="CQFqtb0cq7aPNjqYfv8Cfp">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
+                          <Choice Kind="OperationCallFlag" Name="Atlas" />
+                        </p:NodeReference>
+                        <Pin Id="NlTsVBIYEJqMdwF49f2IS1" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="E4xfi2eTttiPfBoyikEgk7" Name="Output" Kind="StateOutputPin" />
+                        <Pin Id="ABh8vYi42RyLOFOfUrTD3a" Name="Atlas" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="303,1352,104,26" Id="L02ihvU4U2IN8NW7nVSjJO">
+                        <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.ShadowMapAtlasTexture" LastDependency="Stride.Rendering.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="AssemblyCategory" Name="ShadowMapAtlasTexture" />
+                          <Choice Kind="OperationCallFlag" Name="Texture" />
+                        </p:NodeReference>
+                        <Pin Id="MhiVZE8ExfjM50C0mHJy7E" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="BQUedU7EjKAQYI5tQycXHl" Name="Output" Kind="StateOutputPin" />
+                        <Pin Id="O9kDjDoN2rMMA57PUIoUqK" Name="Texture" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="655,1212,146,19" Id="LuvDtMavWW6O6VMDE1fnPg">
+                        <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="GetLightShadowShaderDatas" />
+                        </p:NodeReference>
+                        <Pin Id="T3D3BGF6EoPMbHFtVPneRX" Name="Shadows" Kind="InputPin" />
+                        <Pin Id="OChx0flrnZIMTLFU2mbGiR" Name="Directional" Kind="OutputPin" />
+                        <Pin Id="D7jC3poDn0TPE1tFbNGsuJ" Name="Spot" Kind="OutputPin" />
+                        <Pin Id="EwKKtm4lJV5NKaNyIF9sqA" Name="Point" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="914,963,278,246" Id="EuSLHnTFoycOtdc3KqrsG4">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                          <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                          <CategoryReference Kind="Category" Name="Primitive" />
+                          <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                        </p:NodeReference>
+                        <Pin Id="Am1fr1PE5cvMm7SSHQQuld" Name="Break" Kind="OutputPin" />
+                        <Patch Id="AXepRJLSTJTLER5Nz4IcNk" ManuallySortedPins="true">
+                          <Patch Id="VWOoXiaKZ2CNwwaGDcZgeP" Name="Create" ManuallySortedPins="true" />
+                          <Patch Id="J7BXsZP2M3fObfS4U0O8Cz" Name="Update" ManuallySortedPins="true">
+                            <Pin Id="Bre7dR6uelENvc7426A35S" Name="Keep" Kind="OutputPin" />
+                          </Patch>
+                          <Patch Id="CVBOsRzvXV2LqD47FZGgNk" Name="Dispose" ManuallySortedPins="true" />
+                          <Node Bounds="926,1043,104,26" Id="J3AiMczGVF8Omm5BjUoLrr">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
+                              <Choice Kind="OperationCallFlag" Name="Light" />
+                            </p:NodeReference>
+                            <Pin Id="EcruRoCL07jNS4qPmw9woI" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="SDrolaGiY8TPTvCT4ke9ok" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="T5zK9EQ9yCwOi0JADpx64I" Name="Light" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="931,996,104,26" Id="JdKZjsuRAyPQNrNHcUNl8L">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="RenderLight" />
+                            </p:NodeReference>
+                            <Pin Id="FCG1crtiyPCPjBGAH3sMUV" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="VMCDMPQamL4LGhgCa4MhAG" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="LZSKWNx5rrRNiHxfmuIdsk" Name="Render Light" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="1110,1045,59,26" Id="QjvRUUVGTYIQRLfJXljVCb">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
+                              <Choice Kind="OperationCallFlag" Name="Position" />
+                            </p:NodeReference>
+                            <Pin Id="PwK85ZuXtBLNAZAkreAP67" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="HBzZlpjpc7HLYVKW6mWijF" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="SFRloVy852sMQBYQi0NEFz" Name="Position" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="1095,1099,59,26" Id="UX27QmvdKaRM8lwAloOV9G">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
+                              <Choice Kind="OperationCallFlag" Name="Direction" />
+                            </p:NodeReference>
+                            <Pin Id="J5xQai1staVL0HzAXxk0Y0" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="KEyiVn8JyGzOA75qmUR7BV" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="NQ0kuS9PFXDMlAvsslyJQR" Name="Direction" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="1010,1092,48,19" Id="CHjA5AI2hC2OHgaun2UaPZ">
+                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="CastAs" />
+                            </p:NodeReference>
+                            <Pin Id="UVLCgCSEhc3PGxKfof0PhX" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="FiGlWNpoWiFM2Yvo7ar2U1" Name="Default" Kind="InputPin" />
+                            <Pin Id="ITLGMJ4n2yyO90gYdl03LQ" Name="Result" Kind="OutputPin" />
+                            <Pin Id="KboskSoUCwDMJEat50T0dl" Name="Success" Kind="OutputPin" />
+                          </Node>
+                          <ControlPoint Id="KEeqnwHUS7oMWu6OxJSLB8" Bounds="1059,1137" />
+                          <Node Bounds="945,1152,103,19" Id="MVgzSz6pswDNs16E21ekkj">
+                            <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.Reflection" LastDependency="VL.ShadowCatcher.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="GetSpotLightParam" />
+                            </p:NodeReference>
+                            <Pin Id="Bn3Czs0IWj0P9A73qfamPD" Name="Spot" Kind="InputPin" />
+                            <Pin Id="AhdbJZLCmWZOIDvkxZIdVA" Name="Result" Kind="OutputPin" />
+                          </Node>
+                        </Patch>
+                        <ControlPoint Id="TVKJ6vRLC3cN0ABLdswUFq" Bounds="928,969" Alignment="Top" />
+                        <ControlPoint Id="C4PC4uGuXDJLqZNWjx0l8J" Bounds="1175,1203" Alignment="Bottom" />
+                        <ControlPoint Id="VQiOZYFbsHyLCs79L69Stp" Bounds="1137,1203" Alignment="Bottom" />
+                        <ControlPoint Id="UCU17iaC0s5QDXldldih98" Bounds="995,1203" Alignment="Bottom" />
+                      </Node>
+                      <Node Bounds="892,1245,233,358" Id="TwrCUqrA11sLYdZ38V38Rm">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                          <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                          <CategoryReference Kind="Category" Name="Primitive" />
+                          <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                        </p:NodeReference>
+                        <Pin Id="LCG6G6xmOxYNcOAmg1VQYi" Name="Break" Kind="OutputPin" />
+                        <Patch Id="OKtsbU5DtUCOXdMjmkfmgv" ManuallySortedPins="true">
+                          <Patch Id="IyApAq5SVLRLCzhEoTbox6" Name="Create" ManuallySortedPins="true" />
+                          <Patch Id="StNsKx0a0ClQRackl7ftSL" Name="Update" ManuallySortedPins="true">
+                            <Pin Id="H1DblVE3QaZLwJrrWgTKFs" Name="Keep" Kind="OutputPin" />
+                          </Patch>
+                          <Patch Id="PL6jsbtSGLqPMS9f1NaHs2" Name="Dispose" ManuallySortedPins="true" />
+                          <Node Bounds="904,1328,104,26" Id="Di21HwdpghJQKhc7GekJYp">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
+                              <Choice Kind="OperationCallFlag" Name="Light" />
+                            </p:NodeReference>
+                            <Pin Id="MA9zjcNCndmM7QyzWGUzAA" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="OBZgaDlKk8PLZin3Dl954c" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="Kxo0P986V5UN1kpbOFetm5" Name="Light" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="904,1280,104,26" Id="JpPWUeRcZnENeDls7tgJC5">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="RenderLight" />
+                            </p:NodeReference>
+                            <Pin Id="KTbPjNglWzYL0oqcYU8F5f" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="IrM3q43QLNAMKlp3LzD6bB" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="TdVdcLQRsQmPIyaDsyhFd3" Name="Render Light" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="1046,1481,59,26" Id="SBmD6Ai7ZGtLKKVLqX30wW">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.RenderLight" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="RenderLight" />
+                              <Choice Kind="OperationCallFlag" Name="Position" />
+                            </p:NodeReference>
+                            <Pin Id="Kxqf8eVLRNgLQeDoORxdqA" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="BNHAYdGZWMKL2tuAsNNmEM" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="Kz29DuAjiJxLw2HZzzqgRw" Name="Position" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="952,1377,48,19" Id="KIa19D6Ov5rN3Mpsrqqh48">
+                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="CastAs" />
+                            </p:NodeReference>
+                            <Pin Id="GIWvIy4DUNiPUxhspGcjJT" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="ECbShXctmEFNpREj0txFfw" Name="Default" Kind="InputPin" />
+                            <Pin Id="AEV3l5JkTkyMQaAUYTBYHY" Name="Result" Kind="OutputPin" />
+                            <Pin Id="KEscYD5n0WzM3QFNOWq2tx" Name="Success" Kind="OutputPin" />
+                          </Node>
+                          <ControlPoint Id="TTOlo9lFNUzOIyQDi86vr9" Bounds="1035,1413" />
+                          <Node Bounds="957,1564,46,19" Id="P145wzgQB4bNRqmmrtAGSg">
+                            <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                              <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                            </p:NodeReference>
+                            <Pin Id="IuB1uNx6dqMNkOfdgPf1mo" Name="X" Kind="InputPin" />
+                            <Pin Id="PI13K1QBxVULM5Xkn1N3Wt" Name="Y" Kind="InputPin" />
+                            <Pin Id="OF620sci4mKOL1TIdh5onE" Name="Z" Kind="InputPin" />
+                            <Pin Id="Tqz5lYDzjzHNZ45JjmeyFW" Name="Output" Kind="StateOutputPin" />
+                          </Node>
+                          <Node Bounds="928,1422,92,126" Id="PH3b2P4yQtZNJuSeQeuWcj">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                              <CategoryReference Kind="Category" Name="Primitive" />
+                              <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                            </p:NodeReference>
+                            <Pin Id="HRCyXHooE2FLAIWXn3hHJK" Name="Condition" Kind="InputPin" />
+                            <Patch Id="CAcROP8YuF3Nn5OgO4Dt4Z" ManuallySortedPins="true">
+                              <Patch Id="Nq36FBtApsPN1F18UEgquj" Name="Create" ManuallySortedPins="true" />
+                              <Patch Id="DCFCZhYsmONPNCoYKFnhna" Name="Then" ManuallySortedPins="true" />
+                              <Node Bounds="940,1445,52,26" Id="PFHTCUm1c0JMlnzNgVyFGO">
+                                <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightPoint" LastDependency="Stride.Rendering.dll">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <CategoryReference Kind="AssemblyCategory" Name="LightPoint" />
+                                  <Choice Kind="OperationCallFlag" Name="Radius" />
+                                </p:NodeReference>
+                                <Pin Id="Rh6TPq6DKnhOgOyzWr4UzQ" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="THbpQ2jZwu1LitCWksX7lq" Name="Output" Kind="StateOutputPin" />
+                                <Pin Id="CpDBGsFzPT0MkuVRT4S2dC" Name="Radius" Kind="OutputPin" />
+                              </Node>
+                              <Node Bounds="983,1482,25,19" Id="VUyUNx0UfxqNMvcLsT8Ljz">
+                                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="*" />
+                                </p:NodeReference>
+                                <Pin Id="K4KW4NkreOkNR8BV0IINgq" Name="Input" Kind="InputPin" />
+                                <Pin Id="Fa52iRKCzzqPbs36EJeNpk" Name="Input 2" Kind="InputPin" />
+                                <Pin Id="Q160VSJCO37NtUD288m8zK" Name="Output" Kind="OutputPin" />
+                              </Node>
+                              <Node Bounds="968,1509,25,19" Id="SjSLh62DZVGMuZD8cOjNmH">
+                                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="/" />
+                                </p:NodeReference>
+                                <Pin Id="ADqYoiU1F5KPfoFvPSekht" Name="Input" Kind="InputPin" DefaultValue="1" />
+                                <Pin Id="BhHtLvEUtnhMcQDVevXtLI" Name="Input 2" Kind="InputPin" />
+                                <Pin Id="HxA2oGoIld1OaYT82MX1L7" Name="Output" Kind="OutputPin" />
+                              </Node>
+                            </Patch>
+                            <ControlPoint Id="LeP22HbB2hpMHHOkRto7NQ" Bounds="970,1542" Alignment="Bottom" />
+                            <ControlPoint Id="Kl51l54LPNfLMZtnNoMw5e" Bounds="970,1428" Alignment="Top" />
+                          </Node>
+                        </Patch>
+                        <ControlPoint Id="AY9uvt8yJkXOOKmkZ0uhvf" Bounds="909,1251" Alignment="Top" />
+                        <ControlPoint Id="SIEGajfJOVzQTU4cYFh6Oq" Bounds="1108,1597" Alignment="Bottom" />
+                        <ControlPoint Id="OQgnn745E4JLwLOjCM9vHZ" Bounds="951,1597" Alignment="Bottom" />
+                      </Node>
+                      <Node Bounds="1061,1623,63,26" Id="GLKGlEq7WSSPgR152pU165">
+                        <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                          <Choice Kind="OperationCallFlag" Name="AddRange" />
+                        </p:NodeReference>
+                        <Pin Id="CzFJrtyfyoLMaHcC7sEifJ" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="VN7WxK8MyAhQdmtqCKVwhx" Name="Items" Kind="InputPin" />
+                        <Pin Id="IprvRQmIRp3Mff6Iuj6wTt" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                      <Node Bounds="875,1618,63,26" Id="F0Ya4pTubNWLdaOPHFhQzU">
+                        <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                          <Choice Kind="OperationCallFlag" Name="AddRange" />
+                        </p:NodeReference>
+                        <Pin Id="ETTMvSWft0SNY0yWVA9ttU" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="MR0WZUezhoPQCSKaVLv46D" Name="Items" Kind="InputPin" />
+                        <Pin Id="Ar8wWAtdqZrLnFOl9n8shg" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                      <Node Bounds="477,1065,206,453" Id="Usj6zqsmzF8NbscrVJZpLK">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                          <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                          <CategoryReference Kind="Category" Name="Primitive" />
+                          <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                        </p:NodeReference>
+                        <Pin Id="FKf8ZI2ohmxNMjTqNWKowN" Name="Break" Kind="OutputPin" />
+                        <ControlPoint Id="Um7fh5eF6pVP3enKJKLSft" Bounds="491,1071" Alignment="Top" />
+                        <Patch Id="JZCXjpZ0HVFLTjy2sqPuaM" ManuallySortedPins="true">
+                          <Patch Id="QjXiHvXrFyYMDEIemIMEgL" Name="Create" ManuallySortedPins="true" />
+                          <Patch Id="E2a35aPl8hXPEDww8KWtcg" Name="Update" ManuallySortedPins="true" />
+                          <Patch Id="GJp7cmJcGkBOaOYSUMbXUi" Name="Dispose" ManuallySortedPins="true" />
+                          <Node Bounds="489,1092,104,26" Id="B7XaUMnZHY3P2jIF1jUGFh">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
+                              <Choice Kind="OperationCallFlag" Name="FilterType" />
+                            </p:NodeReference>
+                            <Pin Id="QFB9KwlW4X5Myx1R0A096q" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="PVHWIyMhheOMAuVunW48Cb" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="Egs7tPt35J4NfjuqHGKpb8" Name="Filter Type" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="490,1143,104,26" Id="V0s7NqROBp8LDV9yQcsyTq">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightShadowMapTexture" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapTexture" />
+                              <Choice Kind="OperationCallFlag" Name="Shadow" />
+                            </p:NodeReference>
+                            <Pin Id="PoBObeTgjGZLKjzb3GMdmp" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="QotMo3qMOn3MPtWjSGpsKx" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="HdAQ3G9QEkvLAZuJI7pzh5" Name="Shadow" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="503,1206,77,26" Id="O2Ue0h8KuymPzR6pZ4lR7K">
+                            <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightShadowMap" LastDependency="Stride.Rendering.dll">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="AssemblyCategory" Name="LightShadowMap" />
+                              <Choice Kind="OperationCallFlag" Name="Filter" />
+                            </p:NodeReference>
+                            <Pin Id="F76NwnV837YMVkY3ld24UL" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="KHt55CGj4GkL2icfxeEhpr" Name="Output" Kind="StateOutputPin" />
+                            <Pin Id="AlB26iVgJz6NWUlsOoA3sI" Name="Filter" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="499,1280,48,19" Id="PiYBqVv9E0zOXX6WgkEUxn">
+                            <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <Choice Kind="OperationCallFlag" Name="CastAs" />
+                            </p:NodeReference>
+                            <Pin Id="QN4JKdVOiCLO2EAxr9sjJi" Name="Input" Kind="StateInputPin" />
+                            <Pin Id="E4FZ3kpJtGbM8heGFCStKF" Name="Default" Kind="InputPin" />
+                            <Pin Id="GMTsqiiotBvMxg5TntqbaE" Name="Result" Kind="OutputPin" />
+                            <Pin Id="S3DJKs8Y35ZLdg716NiHr0" Name="Success" Kind="OutputPin" />
+                          </Node>
+                          <Node Bounds="525,1328,146,166" Id="RwA7V8phXI4NVFP29sbC7p">
+                            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                              <CategoryReference Kind="Category" Name="Primitive" />
+                              <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                            </p:NodeReference>
+                            <Pin Id="HQHiJF6QcMoPVLUsd6UueH" Name="Condition" Kind="InputPin" />
+                            <Patch Id="OgXe0WgHlTRMGf57T8wjtg" ManuallySortedPins="true">
+                              <Patch Id="MFqSq9g3xu8OmTHy9I7bzO" Name="Create" ManuallySortedPins="true" />
+                              <Patch Id="HAz2XSLOQRpOBoDhNHURcG" Name="Then" ManuallySortedPins="true" />
+                              <Node Bounds="537,1351,122,26" Id="Eigz0mxgyj9NsOkPNI5Cvk">
+                                <p:NodeReference LastCategoryFullName="Stride.Rendering.Lights.LightShadowMapFilterTypePcf" LastDependency="Stride.Rendering.dll">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <CategoryReference Kind="AssemblyCategory" Name="LightShadowMapFilterTypePcf" />
+                                  <Choice Kind="OperationCallFlag" Name="FilterSize" />
+                                </p:NodeReference>
+                                <Pin Id="A9ts0unFJXOLFlj8uXL6tp" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="OKBxdbFpB5VM1sr1l0jaE3" Name="Output" Kind="StateOutputPin" />
+                                <Pin Id="HV178qBqgwuQCnGIZxf7gd" Name="Filter Size" Kind="OutputPin" />
+                              </Node>
+                              <Node Bounds="550,1387,65,19" Id="SoStqCmofH0QEivkz1Sa5Y">
+                                <p:NodeReference LastCategoryFullName="Primitive.Enum" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="Enum2Ord" />
+                                </p:NodeReference>
+                                <Pin Id="HFqleKocsmHORoi7btmVVz" Name="Input" Kind="StateInputPin" />
+                                <Pin Id="V665FcKCms8PWGxdY5nJm1" Name="Result" Kind="OutputPin" />
+                              </Node>
+                              <Node Bounds="562,1455,25,19" Id="Oxj24Nm8mHkMVuntZFC9OO">
+                                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="+" />
+                                </p:NodeReference>
+                                <Pin Id="IKyBJyxvb0wQaBD4Ode4mR" Name="Input" Kind="InputPin" />
+                                <Pin Id="Sw9yIGiS7vkOmWZ5kex90N" Name="Input 2" Kind="InputPin" />
+                                <Pin Id="BEZarwAysvIMspuy0deuyk" Name="Output" Kind="OutputPin" />
+                              </Node>
+                              <Pad Id="VrzEubzJmbdP4PeuJ1vZkl" Comment="" Bounds="596,1436,35,15" ShowValueBox="true" isIOBox="true" Value="3">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+                                  <CategoryReference Kind="Category" Name="Primitive" />
+                                </p:TypeAnnotation>
+                              </Pad>
+                              <Node Bounds="546,1421,25,19" Id="KFI28NUmG0vP9Hy6iI2IkS">
+                                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                  <Choice Kind="OperationCallFlag" Name="*" />
+                                </p:NodeReference>
+                                <Pin Id="SpMSwmMs50kLOFtWUaMN5a" Name="Input" Kind="InputPin" />
+                                <Pin Id="UdEko70ePprPVXjxsqZsra" Name="Input 2" Kind="InputPin" DefaultValue="2" />
+                                <Pin Id="FfDg5E3U4cUOdjWNxiHOBu" Name="Output" Kind="OutputPin" />
+                              </Node>
+                            </Patch>
+                            <ControlPoint Id="HcIzBmdAu0gO4TJ7VJ2a1Y" Bounds="552,1488" Alignment="Bottom" />
+                            <ControlPoint Id="HFGS8Mth36cQKPbSCowmBt" Bounds="583,1334" Alignment="Top" />
+                          </Node>
+                          <Pad Id="Eg4HiBDb1RlNQk5tA0azWI" Comment="" Bounds="579,1299,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                              <Choice Kind="TypeFlag" Name="Integer32" />
+                            </p:TypeAnnotation>
+                          </Pad>
+                        </Patch>
+                        <ControlPoint Id="H4REWyeL739MdMqsFWdGJU" Bounds="548,1512" Alignment="Bottom" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="E9If2LFOlmCQcXeNb9n8ya" Bounds="538,1666" Alignment="Bottom" />
+                    <ControlPoint Id="NCYoX06VQ03P8hxTdi453c" Bounds="538,949" Alignment="Top" />
+                  </Node>
+                  <Node Bounds="456,909,65,19" Id="D9GTsj1o2d5O2pXML6uNTX">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                    </p:NodeReference>
+                    <Pin Id="Sv6LyKUhAqpMQhtNYrNka4" Name="X" Kind="InputPin" />
+                    <Pin Id="Sg9gXIUmnDgLeL9W1cY2Rw" Name="Result" Kind="OutputPin" />
+                    <Pin Id="Raa7D0SbJx2LO6CTdBtVUE" Name="Not Assigned" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="441,461,80,26" Id="ShOuBrOo0D9LijvDC2XiP1">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderContext" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="RenderContext" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="RenderSystem" />
+                    </p:NodeReference>
+                    <Pin Id="UdzsLL4EI3PMPvYvCc63e2" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="R7K0iVJbjlmMg0hFsaFFnT" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="VADAJm3qfRQMOM1mwltHIK" Name="Render System" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="OZ6PTwxJ3SJMvYx5kZp9wb" Bounds="537,1709" Alignment="Bottom" />
+                <ControlPoint Id="FkTPuZQ17yHOArSymm0zmx" Bounds="537,429" Alignment="Top" />
+              </Node>
+              <Node Bounds="269,386,65,19" Id="KVT2wq1r1XiMD0yvQNnQfh">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                </p:NodeReference>
+                <Pin Id="NcNAejd6XoUL5cgdaClIs8" Name="X" Kind="InputPin" />
+                <Pin Id="BwoCjktVrqDM9DOiymHurL" Name="Result" Kind="OutputPin" />
+                <Pin Id="ADbZeaMWuPfLSXHgItZNzx" Name="Not Assigned" Kind="OutputPin" />
+              </Node>
+              <Pad Id="AnZxI6OnIA9QGhgAX8KJCV" Comment="Texture" Bounds="-111,2118,190,132" ShowValueBox="true" isIOBox="true" />
+              <Node Bounds="276,2230,345,271" Id="EZFdR3oNmLNPzRxTKp6ThF">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                </p:NodeReference>
+                <Pin Id="LYag5tPLty7Pia68OPMGWh" Name="Break" Kind="OutputPin" />
+                <Patch Id="QvRTdJs7s6LP8OShpV3kt9" ManuallySortedPins="true">
+                  <Patch Id="U9ErqahsAP7Lr4TX0ur2ad" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="IXzYJ3vNNVUNG8GTbnqAgi" Name="Update" ManuallySortedPins="true" />
+                  <Patch Id="P2LswoOPA1RQMY6G6tePa4" Name="Dispose" ManuallySortedPins="true" />
+                  <Node Bounds="388,2319,168,26" Id="L3sPgHfXXlbOb9teDBpSah">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="DepthBias" />
+                    </p:NodeReference>
+                    <Pin Id="IwRXYRI9gX5NKbfvDgRJzl" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="PfEFpySOcXRPSBluHUEB3c" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="VNIPdHT0D0wMgfubAVZGY6" Name="Depth Bias" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="288,2378,168,26" Id="OE5AIb6O4v6MtGJzzs3whX">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="WorldToShadowCascadeUV" />
+                    </p:NodeReference>
+                    <Pin Id="D7mfXewDN4jMxmHuf9OZWE" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="VHIESvgxJxrMAjouMzTvJS" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="O7ij6HTNo4rMAu1CqENmkQ" Name="World To Shadow Cascade UV" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="441,2265,168,26" Id="EsLh4ExLjhLORKZFfyWB6p">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightSpotShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightSpotShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="OffsetScale" />
+                    </p:NodeReference>
+                    <Pin Id="JdgnZuIiMn9PTfjfRs7Sec" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="UFLkUgUuKeFPD2OXJ1CFxz" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="EYCfzQa6P1eOXK8GMrqcD5" Name="Offset Scale" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="340,2430,41,26" Id="RL2upH1ty2jQZWpS752nc8">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="TXpcZFp48HuNhBE4khGBA5" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MtDKVSrorZXMv9VO3VPdNb" Name="Item" Kind="InputPin" />
+                    <Pin Id="IhiZC2elF2uNSy4AbuT3Jc" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="480,2407,41,26" Id="P5CRe9cWsltNV8zHSEpnkU">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="DBHUHYbmOwrPKjq8dV0487" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FruyRR0oe0WP6z799bnfTL" Name="Item" Kind="InputPin" />
+                    <Pin Id="L5ZKZpMmCvwOWiWBl5EaEh" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="551,2384,41,26" Id="IBixgR2kXZ3MOiOw3dPF83">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="EvcyKDNdBJJPPXFGyL0jyb" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="OiqbpHg97rAMyul6LVFyRC" Name="Item" Kind="InputPin" />
+                    <Pin Id="DlGnXIKFGzaOMwDmfWgujz" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="SvbtCsHJvs8PSagrb4VW8Q" Bounds="431,2236" Alignment="Top" />
+                <ControlPoint Id="LzA11ptuYUJMOKFWMqcmCZ" Bounds="349,2236" Alignment="Top" />
+                <ControlPoint Id="Klz0bMfWkyaPxnxDiqGrpY" Bounds="341,2495" Alignment="Bottom" />
+                <ControlPoint Id="RYdxwJbwjRVN7YN840dNYP" Bounds="470,2495" Alignment="Bottom" />
+                <ControlPoint Id="NelgVlRr9EJMdoRmWtBWQd" Bounds="470,2236" Alignment="Top" />
+                <ControlPoint Id="IVl2Wi3E1MBM65HcQYs9xZ" Bounds="557,2236" Alignment="Top" />
+                <ControlPoint Id="BEfLlhuAgJaLai7RpfP6jV" Bounds="597,2495" Alignment="Bottom" />
+              </Node>
+              <Node Bounds="719,1756,57,26" Id="C7IoLYmukENOdiXRoDKTGf">
+                <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Count" />
+                </p:NodeReference>
+                <Pin Id="ImK4yEjG5OCNGBpDajVm91" Name="Input" Kind="StateInputPin" />
+                <Pin Id="TwqMZv8aXGiPoslQxjbY7W" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="LKpjjQ5FuL6LkuouSSYNTP" Name="Count" Kind="OutputPin" />
+              </Node>
+              <Pad Id="GUJUczZRIOiMxnSKl698g1" Comment="Spot Light Count" Bounds="681,3154,35,15" ShowValueBox="true" isIOBox="true" Value="2">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="263,1887,321,278" Id="KkaqjdweIQQOEuwrdz8Cei">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                </p:NodeReference>
+                <Pin Id="MIZSa5D0RAOO5VD9nIfCdj" Name="Break" Kind="OutputPin" />
+                <Patch Id="DUJEaL4nRjoOyI7OPopmAg" ManuallySortedPins="true">
+                  <Patch Id="QpmAmRPuFFXQQXqnU3zyn0" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="IZODCbBv2RUOx20HdUitqz" Name="Update" ManuallySortedPins="true" />
+                  <Patch Id="O2NkRtjFV24PEuIJRhgTC9" Name="Dispose" ManuallySortedPins="true" />
+                  <Node Bounds="422,1959,62,26" Id="DWwB6qNZrYBLX2jmYThqDh">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="DepthBias" />
+                    </p:NodeReference>
+                    <Pin Id="HbkYXzcb02UMPesK6CuqUv" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="OtwAZWcA2hvPr7p6wQM69B" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="RzgpTiGLrjbMRXMpxakQ8W" Name="Depth Bias" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="320,2007,139,26" Id="EvlsPlza6UEMH8T1JFoYQx">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="WorldToShadowCascadeUV" />
+                    </p:NodeReference>
+                    <Pin Id="EioJyzlXXDALiABpohulfG" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="PKENBr3mOamNL6flnn2uMn" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="P8clVuztXRHNS4TebnZZWs" Name="World To Shadow Cascade UV" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="473,1910,67,26" Id="P48CVoExY5gPrMZjwsDoRt">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="OffsetScale" />
+                    </p:NodeReference>
+                    <Pin Id="IZdoZhbhB71LCeWCFFBmsm" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="LEEMcex2QOJMbzCYJnghvr" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="RiT6IiKNtjoOrGyyS5N4LJ" Name="Offset Scale" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="386,2066,63,26" Id="BiTngEoBaitLWBDaZpVC5G">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="AddRange" />
+                    </p:NodeReference>
+                    <Pin Id="NMoi8gpdUqeN0IvpRpeIEc" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="B1um3RzPBUSP87UOxwqRqa" Name="Items" Kind="InputPin" />
+                    <Pin Id="A05pOePcTLBOQi0YgGmHBZ" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="305,2102,63,26" Id="I5cFanCDwBbMQleEsG6kpR">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="AddRange" />
+                    </p:NodeReference>
+                    <Pin Id="SnuRrbaDTKnQUVYmrVgSFr" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="IAMUHl2NVcYNwArhFlBj3I" Name="Items" Kind="InputPin" />
+                    <Pin Id="FVi71tHK6IqP0Eafo1z1yw" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="474,2045,41,26" Id="JzJO5JWDA1KQMjmsDhMla8">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="V37vGuYtLcCMOAcKYTOnnN" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="E7UUzwhJK4OOPGuhrjl2bj" Name="Item" Kind="InputPin" />
+                    <Pin Id="EtHVeZYRh1ZPcLsrVS8uu8" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="531,1997,41,26" Id="FYyXwqQJi4zPvZjAq7wNoy">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="Jvi9ieWGn2hL2qDJXvhbMk" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="DSM0DsF6oL7Nucx2QUbfXU" Name="Item" Kind="InputPin" />
+                    <Pin Id="IPX93qdjJzSPfHkSnGvWtw" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="275,2057,78,26" Id="UAw0TqCOPP4L0W5DZTo0h2">
+                    <p:NodeReference LastCategoryFullName="Stride.Rendering.Shadows.LightDirectionalShadowMapRenderer.ShaderData" LastDependency="Stride.Rendering.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="CascadeSplits" />
+                    </p:NodeReference>
+                    <Pin Id="Ib3zh3ecq4vMjDX2xS9wuA" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MyDFMCIX8R4MV1U5Wp4jMg" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="PUTEWOGkEqTPW26GwgQthl" Name="Cascade Splits" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="V2dtmVMr0j5LpRlQFRW2lh" Bounds="479,1893" Alignment="Top" />
+                <ControlPoint Id="GsEdUDqebxmLIhZRypx8Bq" Bounds="390,2159" Alignment="Bottom" />
+                <ControlPoint Id="E7v8hYvG2ByOuZt5KV8ToO" Bounds="395,1893" Alignment="Top" />
+                <ControlPoint Id="M2ZDfu1EfM0NEfALisyaeP" Bounds="310,1893" Alignment="Top" />
+                <ControlPoint Id="MkqMvO5HT8ZOrlwU88RPzW" Bounds="313,2159" Alignment="Bottom" />
+                <ControlPoint Id="NmUh65qVf1dMvXw9IveSMn" Bounds="521,1893" Alignment="Top" />
+                <ControlPoint Id="GYKXbK9jDGXL84LDExpmjy" Bounds="468,2159" Alignment="Bottom" />
+                <ControlPoint Id="SKnyCzCmekELXOQoDxSSVz" Bounds="551,1893" Alignment="Top" />
+                <ControlPoint Id="MrZe6bNAMyKOAkliqPkXOD" Bounds="527,2159" Alignment="Bottom" />
+              </Node>
+              <Node Bounds="616,1744,57,26" Id="SqBiPmFdpA3MhoQwus6UJr">
+                <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Count" />
+                </p:NodeReference>
+                <Pin Id="J4FQ2WQCGnNO3XMHHoI9sI" Name="Input" Kind="StateInputPin" />
+                <Pin Id="BZRav0x8OXIOYPNcmCeU2Y" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="SIaqpnEYLucPVUxOs9Ce5K" Name="Count" Kind="OutputPin" />
+              </Node>
+              <Pad Id="TyU1aOsnahbO3hHDY3pPJN" Comment="Directional Count" Bounds="623,3115,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="573,3255,87,26" Id="CFqyI3wxEfZLO0W7wf8Xu0">
+                <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="RecordType" Name="ShadowCatcherData" />
+                  <Choice Kind="OperationCallFlag" Name="Create" />
+                </p:NodeReference>
+                <Pin Id="T4ItbGGaSg1QKmNYYks85Q" Name="ShadowMap" Kind="InputPin" />
+                <Pin Id="Qd941rcuEU1O2w1dvcrwUc" Name="Buffers" Kind="InputPin" />
+                <Pin Id="PFimkZUAWsiMdJWNHTJdNW" Name="Directional Light Count" Kind="InputPin" />
+                <Pin Id="QzVU2UcCihTNiM4laYE8hR" Name="Spot Light Count" Kind="InputPin" />
+                <Pin Id="NTAc253hGBuQQNS2BWWGTs" Name="Point Light Count" Kind="InputPin" />
+                <Pin Id="T8VtzCkZJHBN27IXNzgofK" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="473,2961,165,19" Id="Co2zzsfIXewPDiBTED4U5j">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Cons" />
+                </p:NodeReference>
+                <Pin Id="DNcee6GAXeIOy6VA7WYSqO" Name="Input" Kind="InputPin" />
+                <Pin Id="PYhL4XzbyWzMYMEoMSMV2M" Name="Input 2" Kind="InputPin" />
+                <Pin Id="FRaVRxD2lnlQQbvQtnrQnt" Name="Result" Kind="OutputPin" />
+                <Pin Id="Fqnp1xm2V4aNoGNjiQQvj4" Name="Input 3" Kind="InputPin" />
+                <Pin Id="HcgGGaU29KRMfkYXrEWHq1" Name="Input 4" Kind="InputPin" />
+                <Pin Id="OiyPHyp9G8BMkBnYIKleTV" Name="Input 5" Kind="InputPin" />
+                <Pin Id="ES8Fx3vTaPAPtGu3fcYYkz" Name="Input 6" Kind="InputPin" />
+                <Pin Id="C0rePlwzJrwMz5JJ6u7Dry" Name="Input 7" Kind="InputPin" />
+                <Pin Id="DKwRBOq9oQRLtiU4dHp0Sb" Name="Input 8" Kind="InputPin" />
+                <Pin Id="FYehU8nX8TNOY6wp1kS9FC" Name="Input 9" Kind="InputPin" />
+              </Node>
+              <Node Bounds="824,1801,57,26" Id="GDQVbvynMPzLltyBribUSP">
+                <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableList" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="MutableList" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Count" />
+                </p:NodeReference>
+                <Pin Id="CgIZNkN7cS9Mtg88dz7nyQ" Name="Input" Kind="StateInputPin" />
+                <Pin Id="EF1t28MXQvgNG0dx4oTmWE" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="S6PTOExkK0UL2laahXEslz" Name="Count" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="KC04UAkUXePNAjwu5ahVsq" Bounds="574,3323" />
+              <Node Bounds="1040,2873,85,19" Id="UDxGrJib8ORPfbJCocmofL">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="UccfNjh3RNfLA9ralM9Lf9" Name="Input" Kind="InputPin" />
+                <Pin Id="AN1dpF8jTuJPbIaqfJk2KO" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="UlOVDKSe12wLeTNCsDfbWM" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="A4zrqFTTHAsPH7vuEIiso1" Name="Recreate" Kind="InputPin" />
+                <Pin Id="FqvfRrc2Ov9Mu8DwOs3RJb" Name="Apply" Kind="InputPin" />
+                <Pin Id="LFhxIesZ1gCPpLRB6QHfns" Name="Output" Kind="OutputPin" />
+                <Pin Id="Heo7WGvnW93Mc2huov1K21" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="509,2857,85,19" Id="NModW5IQXAMQQ301mKBvaZ">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="EHo6mdu7WpWNSCnuf4NvlB" Name="Input" Kind="InputPin" />
+                <Pin Id="CNiBvrz8EIaOXH5SAbYIaU" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="P8VOKOBvYCXOdGkYRyF1Jj" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="BdCVKDXqctzO1b9CDcreCy" Name="Recreate" Kind="InputPin" />
+                <Pin Id="HOLzVIEWlSBOX3RFKk9uFM" Name="Apply" Kind="InputPin" />
+                <Pin Id="BJtHansbOMlL4SCoi85VuB" Name="Output" Kind="OutputPin" />
+                <Pin Id="VmezNmaq7lTPvpmFB10RWd" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="405,2858,85,19" Id="AUQin4oWuxmOUq06VeFBD9">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="VBqOCM7BKKQP7yOaPeTuSN" Name="Input" Kind="InputPin" />
+                <Pin Id="SOwmdFz4fPWLswoorSvQbD" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="UtVK0hmxFnPLS0SnbyXyxu" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="GQdpTXjkKj0O9tl3lIYIYb" Name="Recreate" Kind="InputPin" />
+                <Pin Id="CqjCdNf3c95NGP8YTySPfA" Name="Apply" Kind="InputPin" />
+                <Pin Id="RGzN08YmVr5NLlcOtr5r0x" Name="Output" Kind="OutputPin" />
+                <Pin Id="SjXM2aDCITuLHdUAqXnAtX" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="609,2858,85,19" Id="B8We95HzHFAPk8cEMgHboN">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="BpDYeX1IcEuNLcqCt5mroV" Name="Input" Kind="InputPin" />
+                <Pin Id="URnSRU2hGx2NyVhruUB8IU" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="JS76sAcBUVrMFRCkeN1tI4" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="MKoT1VlLnO2QYrbNcwUtqW" Name="Recreate" Kind="InputPin" />
+                <Pin Id="AmNDrZqmMnZNlGXOukZUnj" Name="Apply" Kind="InputPin" />
+                <Pin Id="SIBBeb8MIRQLB4q2mwWOW5" Name="Output" Kind="OutputPin" />
+                <Pin Id="AgOT4FeNB5eMYeGs7Ntq6U" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="830,2858,85,19" Id="ERYgV92wgmPPAwGaSGc3LW">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="IBUWG4zDIKfLgmJPYFpIbS" Name="Input" Kind="InputPin" />
+                <Pin Id="GFUJ4LwgxafMdn4gKAmDq3" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="BBKnUqtwHS7MsL8C5rwIl5" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="A3w9NnjpcMvMihwWPMoLn7" Name="Recreate" Kind="InputPin" />
+                <Pin Id="UjyldPlrCSOMWxJF0hrNHj" Name="Apply" Kind="InputPin" />
+                <Pin Id="Bzi6yTWXfEEPWFbngX9xWs" Name="Output" Kind="OutputPin" />
+                <Pin Id="UFywhVW3WG4NJ7tBJstvGw" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="715,2853,85,19" Id="InN6NfmAPV5OBWrPlEATB7">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="B10mG1cEvdCNHHkPc49Bth" Name="Input" Kind="InputPin" />
+                <Pin Id="OpOX2hr1cgyP1j1UKvkNNM" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="RfT6v7VPvFhQVf4n6LLIJH" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="Mkj9F4d77nxPkiuh4UztYX" Name="Recreate" Kind="InputPin" />
+                <Pin Id="MrH4ay7q64zLw1Wvaa97U0" Name="Apply" Kind="InputPin" />
+                <Pin Id="LWfb4mesLcZPvXlC5UxDkT" Name="Output" Kind="OutputPin" />
+                <Pin Id="Pqux3sjm3bcOOFsoSJ70YE" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1143,2876,85,19" Id="NGsKOU5f3kXM4cfOuMHd8P">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="QIJS9FNDK0oM3XxJurv95q" Name="Input" Kind="InputPin" />
+                <Pin Id="HLhzpE7NMfVLfyJ28mm6kY" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="S9H6fPl5mJSMFpZ3LhgiEH" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="BWFB1HboRTTMt1gTwreXNZ" Name="Recreate" Kind="InputPin" />
+                <Pin Id="HujeqyK08AZMItrTAa4LLa" Name="Apply" Kind="InputPin" />
+                <Pin Id="BBIg5siPju1LShYdRGBglp" Name="Output" Kind="OutputPin" />
+                <Pin Id="FYhixMYsrHOMZBrckhkjh9" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Pad Id="M5ywSopItgLMDj8P9WR60e" Comment="Point Light Count" Bounds="753,3190,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="262,2545,374,277" Id="H1zaSu3F7ifOLleogLVtvq">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                </p:NodeReference>
+                <Pin Id="KlJu8xqbmlKMk15t4mZZY7" Name="Break" Kind="OutputPin" />
+                <Patch Id="GR8IiDgQR3NMr5ywZnHKNf" ManuallySortedPins="true">
+                  <Patch Id="ScTfCuAEFhPN9Ijx2BGjGH" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="HzgD5on5kRwQaAurM7XNt2" Name="Update" ManuallySortedPins="true" />
+                  <Patch Id="UXupDFzmF36OY6skUhrOSD" Name="Dispose" ManuallySortedPins="true" />
+                  <Node Bounds="294,2632,189,26" Id="AHoRY5fGIc8NWEOdU4jtKE">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="DepthBias" />
+                    </p:NodeReference>
+                    <Pin Id="GF0RP0vtNwzPHs5sdDyVJx" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FuhZdWJuIdBNHgyfpXMAqO" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="RHQ1d6EdYU9LzzUb47GToU" Name="Depth Bias" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="284,2586,189,26" Id="HW2txb6BtbLLfD655gYcJk">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="OffsetScale" />
+                    </p:NodeReference>
+                    <Pin Id="VUGopNt1Iq2QE5v0rCP7u9" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="GFlMLzqs2YHP90ZISyiccq" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="FomkkEhIDL9QbwoKsPehRW" Name="Offset Scale" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="283,2678,189,26" Id="L2Bm0cvXa2QOH5aJcgQR4a">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="WorldToShadow" />
+                    </p:NodeReference>
+                    <Pin Id="H4Wmx23qkhZP84MQzbRQCQ" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FtPYlXaof10M5DMJnL6w3E" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="Fjk9RJvonWANP4MA9nlpBy" Name="World To Shadow" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="274,2720,189,26" Id="EWHF6DkReSdNLbZii2UblZ">
+                    <p:NodeReference LastCategoryFullName="VL.ShadowCatcher.ReflectionLightPointCubeShadowMapShaderData" LastDependency="VL.ShadowCatcher.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ReflectionLightPointCubeShadowMapShaderData" />
+                      <Choice Kind="OperationCallFlag" Name="DepthParameters" />
+                    </p:NodeReference>
+                    <Pin Id="B6RVcQ2krHmPWQNB6BR3hI" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MnX47bHIQnLPE8XTkt8FAa" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="NzsLnnyWIBbOC1U9TrZp4q" Name="Depth Parameters" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="583,2657,41,26" Id="KoC9Mbo1dHsQJv2PUWxgTS">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="NYhPMLtuAgFOVab7zaUXH4" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="D5iO0hwLFoDLokYE8wmvGI" Name="Item" Kind="InputPin" />
+                    <Pin Id="HXvfFgch1xlLT1PiYuJEnp" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="514,2676,41,26" Id="JkaDh87MtlGPiRJs1Xb9NB">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Add" />
+                    </p:NodeReference>
+                    <Pin Id="Scb96ko6ItTN72jEdJzhs3" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="GjNJK6HvJevONu7jtewZnk" Name="Item" Kind="InputPin" />
+                    <Pin Id="TDEwbvySliGPhnasN9LRgT" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="406,2763,63,26" Id="NAYTQJs375lMkc27nMOY5o">
+                    <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="AddRange" />
+                    </p:NodeReference>
+                    <Pin Id="HDsSay3nwUxMb4Fjoi1ePp" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="KF3cBJDExaBObpRUALMdtm" Name="Items" Kind="InputPin" />
+                    <Pin Id="Ivui4jrhqR4NNiEORgFtHk" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="H5naPXMWzfPL1daJsi1NXq" Bounds="310,2551" Alignment="Top" />
+                <ControlPoint Id="Cq4TCEzQvq2POURWkhnJ9r" Bounds="578,2551" Alignment="Top" />
+                <ControlPoint Id="LcUsAXcV46cNU622Bi8voy" Bounds="591,2816" Alignment="Bottom" />
+                <ControlPoint Id="FzyPv6fwwQ4P8Zge3kvWgY" Bounds="514,2551" Alignment="Top" />
+                <ControlPoint Id="HYLsgUN6F0cOAQW8hjO8Lj" Bounds="517,2816" Alignment="Bottom" />
+                <ControlPoint Id="LbqdpAnucEeOl3XdMbuYL1" Bounds="372,2551" Alignment="Top" />
+                <ControlPoint Id="F1pjUrsuO8UOwtjgXcIsEd" Bounds="438,2816" Alignment="Bottom" />
+                <ControlPoint Id="DITyS6shaktPaWHj7cb5DP" Bounds="297,2816" Alignment="Bottom" />
+              </Node>
+              <Node Bounds="289,2874,85,19" Id="OjwKjBAlCsYPcXP4NAOMlE">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="CnYYXQV7U42QUckXMKJO7j" Name="Input" Kind="InputPin" />
+                <Pin Id="SVv9ljCQ1zTLxgRXtitsHy" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="FHJP6EGXDMzPPbMTcmHBNu" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="RMMERNBupaVOWy8vMzXjSG" Name="Recreate" Kind="InputPin" />
+                <Pin Id="JwK5hXlKOp7MZeVAMvBJvj" Name="Apply" Kind="InputPin" />
+                <Pin Id="JXJj5RW4FtTLdsFJzeNczx" Name="Output" Kind="OutputPin" />
+                <Pin Id="GnM8sHpt7xwMbl0CC26c4s" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="I5Po9dAHTKnMVrtbvHadhW" Bounds="-106,1837" />
+              <Node Bounds="936,2859,85,19" Id="MjC0rRnXfzeLjh5OknKvva">
+                <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="DynamicBuffer" />
+                </p:NodeReference>
+                <Pin Id="Fn5cOKd4zlyMSzuwIpLomU" Name="Input" Kind="InputPin" />
+                <Pin Id="QBHuL1KVCVMOmXxNEFwC72" Name="Element Size In Bytes" Kind="InputPin" />
+                <Pin Id="OXFuZz2tBFwO7o2VPzWXCM" Name="Offset In Bytes" Kind="InputPin" />
+                <Pin Id="MZecxF7nFQ8NuI9OyKr8YX" Name="Recreate" Kind="InputPin" />
+                <Pin Id="PKVW1tsRMuVPKHHe31zGHr" Name="Apply" Kind="InputPin" />
+                <Pin Id="PcFNk1bRVo7Priklx16g5b" Name="Output" Kind="OutputPin" />
+                <Pin Id="JOxexJ7QnedNgbv82dOZiG" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="MF4SFGcMTt4L1DSGJRcag3" Bounds="-106,2761" />
+            </Canvas>
+            <ProcessDefinition Id="BzAuuX3Bz7nN0XKaPzM2Ep">
+              <Fragment Id="VQOSja4Coj2LGQWZaJAYbc" Patch="JKnhKrOevYqL0hY9I4Vyzg" Enabled="true" />
+              <Fragment Id="I8jxHtByjbXQa9FESYzChc" Patch="PGr9qLP9RR5NZEXwR8ucxz" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="AsBGdVzJ2o2QcJlVMbQE1c" Ids="QJEPsbKsDgUQJw4zBSYWaS,I0g2MNpsm6ZNFifBoRUF0z" IsHidden="true" />
+            <Link Id="OvaWqtMN2dqQFgySDhXJOb" Ids="I0g2MNpsm6ZNFifBoRUF0z,NcNAejd6XoUL5cgdaClIs8" />
+            <Link Id="Sgc98DndjhVMcOrh48vYl0" Ids="BwoCjktVrqDM9DOiymHurL,SQtbV1jbCPrPdAp7KWD7n8" />
+            <Link Id="OQnFkqac5m3POwBoEBhl3C" Ids="L3cHNgrsAyUNCxrMD09MU1,O9rhKVSqEMdNSKWhZW5nOx" />
+            <Link Id="HpPfWomuAihMSqJHBxqX3g" Ids="JmJerhqYOrjMMu0purFbnL,MBv7nUQzuzUMqMWz0PJqHU" />
+            <Link Id="NQzo6jkltWNNPRjxNtv61F" Ids="H5qi1XPy98ILyM8UWQVTbX,P1SOwe1xHIwOLPFh8grrXQ" />
+            <Link Id="EdswkVNpooNNcS7crHdz5t" Ids="LfLT1P6GjFuP0a7GtkjEFX,SBzctdViuHDPFazil2mOwV" />
+            <Link Id="VfE5n106CRXPcOFJ2zQwCt" Ids="TshbPAps052P2fT4Dcc8qu,M1isOSM0499MJy3RzHUBZo" />
+            <Link Id="ITrNbCPFj9rOikilBKV1y3" Ids="SkjzjFsJIANNcsQpHMU9CG,Mz7doCkSwntNLfrrDbW4Q5" />
+            <Link Id="GXFTmjAkvdNL11Kv73UWzf" Ids="EWzQnfakDs7PKqpXxDhoow,Dz7HnNgWTlQOMOSyS5K1dh" />
+            <Link Id="T7I4cYu4E2CL8XHUwCL5WQ" Ids="Qlx0drSEHV8LBqr15sHagk,QK4bKFpKXaALRAXgtkTTJI" />
+            <Link Id="L7tuu3DFYugMX07uOhkd42" Ids="R22Ehl4Kax5LkO9s72Hx1v,UMkauxr1MG0MefK59oEOgI" />
+            <Link Id="MXIVasakDFGLS6RqHyeqpP" Ids="F5s9wSV55O2L9IY6cwOWHj,TSPjclY1HOKL30NCIfYsw8" />
+            <Link Id="QHNChfoCRh5MSzBQCztORH" Ids="PggSSliOLndLnBwRZkYoe9,JCldUWGOvcPMmN0594EQAX" />
+            <Link Id="DrdGqJdSP7kPxjruj6Ul9e" Ids="TRRI1whBMgILZsekpYV0lp,T3D3BGF6EoPMbHFtVPneRX" />
+            <Link Id="JzqUgMuMYUWMEHfIZXIEs6" Ids="Iy4HwBwEqSBOsyBvKOfRb4,RU3goxYONyANponSD1eDzU" IsFeedback="true" />
+            <Link Id="DGENnSF6X7nO4WztYSMdjH" Ids="ED2oz49Ck2oQMP3fVCoV0L,I5UtU51hlIgM1UYfYKyLhg" IsFeedback="true" />
+            <Link Id="Mr0mYpUcnF9MlE1rC6iKuN" Ids="E8uu2M5bGCAPjOTfAwTqGI,PHYK54lLvFbM6pUnBFTVfS" IsFeedback="true" />
+            <Link Id="MU4riCr0GBnP49bOtw95M1" Ids="TRRI1whBMgILZsekpYV0lp,Qav7LB4JA1gON5PT3SyeNR" />
+            <Link Id="SJdoIrWGlxBOvXnqPHd4qK" Ids="A5Bv3SGvncCOLMCWTpd3og,GhcjcUpVOyEQSZajxj5ww5" IsFeedback="true" />
+            <Link Id="F4ksNUQFP7nOfDva1U12cD" Ids="TRRI1whBMgILZsekpYV0lp,TVKJ6vRLC3cN0ABLdswUFq" />
+            <Link Id="J3exVcYPkJ9LYHtJBuDw9e" Ids="BKmQRPOsyGlLvnQNG1EqDv,FiGlWNpoWiFM2Yvo7ar2U1" />
+            <Link Id="JmIGTa64BYbM2YF0edTOTZ" Ids="TejA9u6u4PPOZXbqaXih2k,T8BgaExhL2GN6IIVTNyMTn" IsFeedback="true" />
+            <Link Id="GhxSPK9hZv9PR4Z9dJmiZj" Ids="UV0Gkn4qLHSNdqCPalzTS0,K4K1Le5vhAvQST7AwDJY2n" IsFeedback="true" />
+            <Link Id="Q86znPLsl93P7bxGG3SmAu" Ids="Hq2tV2m2Ud6QGZZiQqvap6,EzH6I7or5joMvrXL9qZqM7" IsFeedback="true" />
+            <Link Id="QcNJJvY3eNJQQWYGlAiNvQ" Ids="KoL14pEnY79NaPwRYbLU8y,Sv6LyKUhAqpMQhtNYrNka4" />
+            <Link Id="SGCAibofrgvOdjfnfMbJ6X" Ids="Sg9gXIUmnDgLeL9W1cY2Rw,LqIYuL5CQaeN9iARmn2USm" />
+            <Link Id="ElqxZjVE9sUOJTHbybTbsY" Ids="ABh8vYi42RyLOFOfUrTD3a,MhiVZE8ExfjM50C0mHJy7E" />
+            <Link Id="GeVcvaNwY2EP5DjWa6Vgzf" Ids="VJloK0ficxcLXIiZseXR3H,HyA9KfBu6CmPhSd8nXvF0T" IsFeedback="true" />
+            <Link Id="BOkRBE1eV25NUL3FtWtcfE" Ids="O9kDjDoN2rMMA57PUIoUqK,HyA9KfBu6CmPhSd8nXvF0T" />
+            <Link Id="VJbVLl4uNSIMYyEZex3DQW" Ids="HyA9KfBu6CmPhSd8nXvF0T,GhcjcUpVOyEQSZajxj5ww5" />
+            <Link Id="AXKANhCdLDKM8POclIsOrB" Ids="CLvx9DeLSZQMiYuRGU8YqK,DrE4D719LJjL5u0z8iS9wV" IsFeedback="true" />
+            <Link Id="HfkkqDKKo6lM4yGE6deTtk" Ids="OChx0flrnZIMTLFU2mbGiR,DrE4D719LJjL5u0z8iS9wV" />
+            <Link Id="EozxnYsqAGgNZ7tGceCFun" Ids="DrE4D719LJjL5u0z8iS9wV,RU3goxYONyANponSD1eDzU" />
+            <Link Id="P0E1LuMrJFMPLSYDJgEWv9" Ids="JrCMgumaXpoMWnhrZazwQP,OEDJj0DhTEZOQtz2Ltvqcr" IsFeedback="true" />
+            <Link Id="RP3y0O6ueikPIoLbf2IYEu" Ids="D7jC3poDn0TPE1tFbNGsuJ,OEDJj0DhTEZOQtz2Ltvqcr" />
+            <Link Id="IGzfHUsIMP6MHZJXGd0v2o" Ids="OEDJj0DhTEZOQtz2Ltvqcr,I5UtU51hlIgM1UYfYKyLhg" />
+            <Link Id="FAwVDJr3a0vMCb76dppXoi" Ids="NDO6NknCKEPO4AQ23v2Eqk,BX7i6c2g9cpOB8PUivn9hy" IsFeedback="true" />
+            <Link Id="EfXngRQu4rVQMffptb4YiU" Ids="EwKKtm4lJV5NKaNyIF9sqA,BX7i6c2g9cpOB8PUivn9hy" />
+            <Link Id="Sn57puLAnhEN0wnc33MXRy" Ids="BX7i6c2g9cpOB8PUivn9hy,PHYK54lLvFbM6pUnBFTVfS" />
+            <Link Id="TIUqDuqnpVpQBuCKsIzRaI" Ids="TVKJ6vRLC3cN0ABLdswUFq,FCG1crtiyPCPjBGAH3sMUV" />
+            <Link Id="MD4o5eHk5GYL12SJQqO7T6" Ids="LZSKWNx5rrRNiHxfmuIdsk,PwK85ZuXtBLNAZAkreAP67" />
+            <Link Id="QtUsKQywab2QNq0f8Hew45" Ids="HBzZlpjpc7HLYVKW6mWijF,J5xQai1staVL0HzAXxk0Y0" />
+            <Link Id="VktAqsb6LVhLJ4Lprqun7Q" Ids="VMCDMPQamL4LGhgCa4MhAG,EcruRoCL07jNS4qPmw9woI" />
+            <Link Id="TUvgyhW6iLiOZymDANsMt8" Ids="KEeqnwHUS7oMWu6OxJSLB8,Bre7dR6uelENvc7426A35S" IsHidden="true" />
+            <Link Id="ThEdAgeWptHPcbTB03lHGc" Ids="KboskSoUCwDMJEat50T0dl,KEeqnwHUS7oMWu6OxJSLB8" />
+            <Link Id="TdJavSPoAhcM9vo4Ens60b" Ids="T5zK9EQ9yCwOi0JADpx64I,UVLCgCSEhc3PGxKfof0PhX" />
+            <Link Id="MkRXMFqduMLMvh5OSTAXlL" Ids="ITLGMJ4n2yyO90gYdl03LQ,Bn3Czs0IWj0P9A73qfamPD" />
+            <Link Id="IKZPfGi4Jd9LNILiUK7K7L" Ids="SFRloVy852sMQBYQi0NEFz,C4PC4uGuXDJLqZNWjx0l8J" />
+            <Link Id="JtnA6emzcmjP9sTpm38hR7" Ids="NQ0kuS9PFXDMlAvsslyJQR,VQiOZYFbsHyLCs79L69Stp" />
+            <Link Id="OI58toqhv4lQOj9hx4HARl" Ids="I9NdXs5bam3M3RgaGq3Ipd,BWZnOtWow1rLpJqgcbOWVr" IsFeedback="true" />
+            <Link Id="HpUdPGNrJEzOKEyYZ6rUVk" Ids="BWZnOtWow1rLpJqgcbOWVr,T8BgaExhL2GN6IIVTNyMTn" />
+            <Link Id="OQiXlz9Xj64PbeyZdSLHgw" Ids="R8EsaKJZNpkQXsAcROtckE,V4Ih6a8LuFxNylplV73xF2" IsFeedback="true" />
+            <Link Id="HxWhzIXaOuEL4xWtX0cbHJ" Ids="V4Ih6a8LuFxNylplV73xF2,K4K1Le5vhAvQST7AwDJY2n" />
+            <Link Id="J5iQjh6ZV3lOw6KIxUNE5B" Ids="Ch3xmWAQACNOawikQwl45v,BK1KdjsPjvvOdoQ4kAIFmv" IsFeedback="true" />
+            <Link Id="OQmHGdyjaawPF5x0H4z1S8" Ids="VQiOZYFbsHyLCs79L69Stp,BK1KdjsPjvvOdoQ4kAIFmv" />
+            <Link Id="NhLJietzshnP3OOXOYu7jL" Ids="BK1KdjsPjvvOdoQ4kAIFmv,EzH6I7or5joMvrXL9qZqM7" />
+            <Link Id="Cs1fchnL9DgO5HpxTPLYud" Ids="PfEFpySOcXRPSBluHUEB3c,D7mfXewDN4jMxmHuf9OZWE" />
+            <Link Id="VXIRqHl2HSTNnW2aK8CDRs" Ids="UFLkUgUuKeFPD2OXJ1CFxz,IwRXYRI9gX5NKbfvDgRJzl" />
+            <Link Id="VhZSxJv2MPZPwXJKbF0GmK" Ids="SvbtCsHJvs8PSagrb4VW8Q,JdgnZuIiMn9PTfjfRs7Sec" />
+            <Link Id="AkR1zXMSF0OOdS4fyvPTHN" Ids="LKpjjQ5FuL6LkuouSSYNTP,GUJUczZRIOiMxnSKl698g1" />
+            <Link Id="KGD2L137toyLeNuUkFwXYq" Ids="OtwAZWcA2hvPr7p6wQM69B,EioJyzlXXDALiABpohulfG" />
+            <Link Id="JOlKKQ4Mo56OsNEIVgmXML" Ids="V2dtmVMr0j5LpRlQFRW2lh,IZdoZhbhB71LCeWCFFBmsm" />
+            <Link Id="E91GvuQTTz7LnQjRfvX7td" Ids="LEEMcex2QOJMbzCYJnghvr,HbkYXzcb02UMPesK6CuqUv" />
+            <Link Id="QXZYMmXPN1EPe8C2kX80Er" Ids="O7ij6HTNo4rMAu1CqENmkQ,MtDKVSrorZXMv9VO3VPdNb" />
+            <Link Id="F7S8M2JvGs1QOC2JYwfQqh" Ids="LzA11ptuYUJMOKFWMqcmCZ,Klz0bMfWkyaPxnxDiqGrpY" IsFeedback="true" />
+            <Link Id="AVDdSW26b53MhhCZPnXtDh" Ids="LzA11ptuYUJMOKFWMqcmCZ,TXpcZFp48HuNhBE4khGBA5" />
+            <Link Id="VpIudhCLeUPLsOtpTChiSb" Ids="IhiZC2elF2uNSy4AbuT3Jc,Klz0bMfWkyaPxnxDiqGrpY" />
+            <Link Id="C552iqRD7RJLMK8XfO0Koq" Ids="P8clVuztXRHNS4TebnZZWs,B1um3RzPBUSP87UOxwqRqa" />
+            <Link Id="Re1ttn3Krr4McXvI3dyJwd" Ids="E7v8hYvG2ByOuZt5KV8ToO,GsEdUDqebxmLIhZRypx8Bq" IsFeedback="true" />
+            <Link Id="Q8Oua2r1a6TPYlbAnA8qgp" Ids="A05pOePcTLBOQi0YgGmHBZ,GsEdUDqebxmLIhZRypx8Bq" />
+            <Link Id="C8zjdlIDAwdMOL8sfJi8Oz" Ids="E7v8hYvG2ByOuZt5KV8ToO,NMoi8gpdUqeN0IvpRpeIEc" />
+            <Link Id="DalGJTQLodbL1FYIrxC7eV" Ids="M2ZDfu1EfM0NEfALisyaeP,MkqMvO5HT8ZOrlwU88RPzW" IsFeedback="true" />
+            <Link Id="RdlxJaKoxbeLRDlyCXEGYg" Ids="M2ZDfu1EfM0NEfALisyaeP,SnuRrbaDTKnQUVYmrVgSFr" />
+            <Link Id="U9PAa8XRXIYPfJzWZTB565" Ids="FVi71tHK6IqP0Eafo1z1yw,MkqMvO5HT8ZOrlwU88RPzW" />
+            <Link Id="RnX7REh0WBJNTtcNEQg05h" Ids="VNIPdHT0D0wMgfubAVZGY6,FruyRR0oe0WP6z799bnfTL" />
+            <Link Id="DGg5IA4NHnbNLoAyBlcbPZ" Ids="NelgVlRr9EJMdoRmWtBWQd,RYdxwJbwjRVN7YN840dNYP" IsFeedback="true" />
+            <Link Id="OuPUdFVGZhfP8IyARkwnUh" Ids="L5ZKZpMmCvwOWiWBl5EaEh,RYdxwJbwjRVN7YN840dNYP" />
+            <Link Id="EFtiQHJppZvN1LwsECggAe" Ids="NelgVlRr9EJMdoRmWtBWQd,DBHUHYbmOwrPKjq8dV0487" />
+            <Link Id="EHx3n7IsPc9LUnSAtQFDHk" Ids="NmUh65qVf1dMvXw9IveSMn,GYKXbK9jDGXL84LDExpmjy" IsFeedback="true" />
+            <Link Id="NZg2yfPmrVhNsofrUU64Mu" Ids="NmUh65qVf1dMvXw9IveSMn,V37vGuYtLcCMOAcKYTOnnN" />
+            <Link Id="KwW2AhjTXvNLpcEKPMxY4f" Ids="RzgpTiGLrjbMRXMpxakQ8W,E7UUzwhJK4OOPGuhrjl2bj" />
+            <Link Id="Fh9C3Bp7jWIOfJAiyvqp1K" Ids="EtHVeZYRh1ZPcLsrVS8uu8,GYKXbK9jDGXL84LDExpmjy" />
+            <Link Id="CYbo4ZeaI2rOlkBElIeH70" Ids="RiT6IiKNtjoOrGyyS5N4LJ,DSM0DsF6oL7Nucx2QUbfXU" />
+            <Link Id="DJFD0uaUH3cPSM1j6j6Cyn" Ids="SKnyCzCmekELXOQoDxSSVz,MrZe6bNAMyKOAkliqPkXOD" IsFeedback="true" />
+            <Link Id="JTdoYLvadImMOs7jETR2uN" Ids="SKnyCzCmekELXOQoDxSSVz,Jvi9ieWGn2hL2qDJXvhbMk" />
+            <Link Id="IEOaeJBQcxNNLybvlbSxLG" Ids="IPX93qdjJzSPfHkSnGvWtw,MrZe6bNAMyKOAkliqPkXOD" />
+            <Link Id="BH3JliOb15ZQBqutdBdcTi" Ids="EYCfzQa6P1eOXK8GMrqcD5,OiqbpHg97rAMyul6LVFyRC" />
+            <Link Id="UeylxAihqgGLeKQ4P37tbv" Ids="IVl2Wi3E1MBM65HcQYs9xZ,BEfLlhuAgJaLai7RpfP6jV" IsFeedback="true" />
+            <Link Id="IpYuV5XFGLbODmAauMqU0s" Ids="IVl2Wi3E1MBM65HcQYs9xZ,EvcyKDNdBJJPPXFGyL0jyb" />
+            <Link Id="T8Ot7XUPWsnNs0CWJBaAR9" Ids="DlGnXIKFGzaOMwDmfWgujz,BEfLlhuAgJaLai7RpfP6jV" />
+            <Link Id="GCb8AvYV1e3NMEOHM2N9En" Ids="SIaqpnEYLucPVUxOs9Ce5K,TyU1aOsnahbO3hHDY3pPJN" />
+            <Link Id="CRGILhwOTgHNllEwzGB246" Ids="BZRav0x8OXIOYPNcmCeU2Y,V2dtmVMr0j5LpRlQFRW2lh" />
+            <Link Id="SR1zRsXU2ieMOHb3xNwvyJ" Ids="TwqMZv8aXGiPoslQxjbY7W,SvbtCsHJvs8PSagrb4VW8Q" />
+            <Link Id="Vkxt6tuUoQgPhFRUBEMHHK" Ids="MrZe6bNAMyKOAkliqPkXOD,IVl2Wi3E1MBM65HcQYs9xZ" />
+            <Link Id="LFXYVxqKQCbQAMLm7OjLG2" Ids="GYKXbK9jDGXL84LDExpmjy,NelgVlRr9EJMdoRmWtBWQd" />
+            <Link Id="Gmezc9aVVx3Li4wOqQ1Mi8" Ids="GsEdUDqebxmLIhZRypx8Bq,LzA11ptuYUJMOKFWMqcmCZ" />
+            <Link Id="THncVKEwpo2NidFZktvq6b" Ids="FRaVRxD2lnlQQbvQtnrQnt,Qd941rcuEU1O2w1dvcrwUc" />
+            <Link Id="L6cpMK2hwkzN52H23YSmCH" Ids="TyU1aOsnahbO3hHDY3pPJN,PFimkZUAWsiMdJWNHTJdNW" />
+            <Link Id="BY2SqRszJv6OasXbURBIzi" Ids="GUJUczZRIOiMxnSKl698g1,QzVU2UcCihTNiM4laYE8hR" />
+            <Link Id="BqTGkuf1Zq3OnmvdzK8AUZ" Ids="RU3goxYONyANponSD1eDzU,J4FQ2WQCGnNO3XMHHoI9sI" />
+            <Link Id="KRkbHISAquZOoX1Q3lcXvS" Ids="I5UtU51hlIgM1UYfYKyLhg,ImK4yEjG5OCNGBpDajVm91" />
+            <Link Id="MFKoBt4So2ENiYILbjXIii" Ids="PHYK54lLvFbM6pUnBFTVfS,CgIZNkN7cS9Mtg88dz7nyQ" />
+            <Link Id="IetDrTRMInmPjiMrsGBLzz" Ids="GhcjcUpVOyEQSZajxj5ww5,I5Po9dAHTKnMVrtbvHadhW,AnZxI6OnIA9QGhgAX8KJCV" />
+            <Link Id="OgNuwCrDrNXMgvxJlFXRdq" Ids="T8VtzCkZJHBN27IXNzgofK,KC04UAkUXePNAjwu5ahVsq" />
+            <Link Id="Re3i9KwIt01OSesJ6vv1wr" Ids="KC04UAkUXePNAjwu5ahVsq,BZAXSj54xIfOod1bqEALjt" IsHidden="true" />
+            <Patch Id="JKnhKrOevYqL0hY9I4Vyzg" Name="Create" />
+            <Patch Id="PGr9qLP9RR5NZEXwR8ucxz" Name="Update">
+              <Pin Id="QJEPsbKsDgUQJw4zBSYWaS" Name="Input" Kind="InputPin" Bounds="547,272" />
+              <Pin Id="BZAXSj54xIfOod1bqEALjt" Name="Output" Kind="OutputPin" Bounds="614,2431" />
+            </Patch>
+            <Link Id="HP9DkL1sTpCLbEWRSXe4L4" Ids="MkqMvO5HT8ZOrlwU88RPzW,UccfNjh3RNfLA9ralM9Lf9" />
+            <Link Id="TXlVy3rpHPJOBPsJFT7vMc" Ids="BJtHansbOMlL4SCoi85VuB,PYhL4XzbyWzMYMEoMSMV2M" />
+            <Link Id="TJTW039SpmXOWKkydvRoCx" Ids="RGzN08YmVr5NLlcOtr5r0x,DNcee6GAXeIOy6VA7WYSqO" />
+            <Link Id="URZLmUcv3XUPXoqbr1w8vO" Ids="SIBBeb8MIRQLB4q2mwWOW5,Fqnp1xm2V4aNoGNjiQQvj4" />
+            <Link Id="FqWT607o6OLOkh4E1Ia2YS" Ids="T8BgaExhL2GN6IIVTNyMTn,IBUWG4zDIKfLgmJPYFpIbS" />
+            <Link Id="VkMZy281wFANlhK3UampJd" Ids="K4K1Le5vhAvQST7AwDJY2n,B10mG1cEvdCNHHkPc49Bth" />
+            <Link Id="V5jEt5O4MDhM2gRSrk122B" Ids="EzH6I7or5joMvrXL9qZqM7,QIJS9FNDK0oM3XxJurv95q" />
+            <Link Id="LWWoDnHLbHzQbPWlYZnvAD" Ids="M5ywSopItgLMDj8P9WR60e,NTAc253hGBuQQNS2BWWGTs" />
+            <Link Id="ToR8dRtfwfVMaJvrmA6wuK" Ids="S6PTOExkK0UL2laahXEslz,M5ywSopItgLMDj8P9WR60e" />
+            <Link Id="EMvp2uAKN6fLkXts79Pcmy" Ids="EF1t28MXQvgNG0dx4oTmWE,H5naPXMWzfPL1daJsi1NXq" />
+            <Link Id="TH9wxvd6NoBLKJViWrAYKg" Ids="H5naPXMWzfPL1daJsi1NXq,VUGopNt1Iq2QE5v0rCP7u9" />
+            <Link Id="R0DiZJsO25rNT9UqVWXmuA" Ids="GFlMLzqs2YHP90ZISyiccq,GF0RP0vtNwzPHs5sdDyVJx" />
+            <Link Id="AjbXbDg5QUeQXYvaMaXwZ2" Ids="FuhZdWJuIdBNHgyfpXMAqO,H4Wmx23qkhZP84MQzbRQCQ" />
+            <Link Id="INyuLp3kQAROAQT0rzIm21" Ids="FtPYlXaof10M5DMJnL6w3E,B6RVcQ2krHmPWQNB6BR3hI" />
+            <Link Id="Q4N5Vy32wmWNkOUEvosMAa" Ids="Cq4TCEzQvq2POURWkhnJ9r,LcUsAXcV46cNU622Bi8voy" IsFeedback="true" />
+            <Link Id="PGpIVvhAqVhMetk6faC3Ut" Ids="BEfLlhuAgJaLai7RpfP6jV,Cq4TCEzQvq2POURWkhnJ9r" />
+            <Link Id="ORm5cpKL50gL1l5t6u6ZKW" Ids="Cq4TCEzQvq2POURWkhnJ9r,NYhPMLtuAgFOVab7zaUXH4" />
+            <Link Id="OPwHWt3A88BOnAHKH2DMvw" Ids="FomkkEhIDL9QbwoKsPehRW,D5iO0hwLFoDLokYE8wmvGI" />
+            <Link Id="VTXPOe969x9OieeEeEuPH2" Ids="HXvfFgch1xlLT1PiYuJEnp,LcUsAXcV46cNU622Bi8voy" />
+            <Link Id="Mbt0Frq1uwVLznL4ru7HiF" Ids="LcUsAXcV46cNU622Bi8voy,BpDYeX1IcEuNLcqCt5mroV" />
+            <Link Id="P2NahXsLftZLr4aUGjkBPu" Ids="FzyPv6fwwQ4P8Zge3kvWgY,HYLsgUN6F0cOAQW8hjO8Lj" IsFeedback="true" />
+            <Link Id="EVZaxK00j2IN8N5UpuGMfm" Ids="RYdxwJbwjRVN7YN840dNYP,FzyPv6fwwQ4P8Zge3kvWgY" />
+            <Link Id="K8YvmjwdjMbMO7iQ3IMDSx" Ids="FzyPv6fwwQ4P8Zge3kvWgY,Scb96ko6ItTN72jEdJzhs3" />
+            <Link Id="CtB0Efj0TmdNj7IPFpfDI2" Ids="RHQ1d6EdYU9LzzUb47GToU,GjNJK6HvJevONu7jtewZnk" />
+            <Link Id="CPIeDZPGL0iLTE9kZv7Fvf" Ids="TDEwbvySliGPhnasN9LRgT,HYLsgUN6F0cOAQW8hjO8Lj" />
+            <Link Id="HUHyThSn2UJOkMRSTdZQX9" Ids="HYLsgUN6F0cOAQW8hjO8Lj,EHo6mdu7WpWNSCnuf4NvlB" />
+            <Link Id="K6GFU1uKoRSMWVYdHfAxgO" Ids="Fjk9RJvonWANP4MA9nlpBy,KF3cBJDExaBObpRUALMdtm" />
+            <Link Id="RHDyOkmo8qLLVT2Z8V75gB" Ids="LbqdpAnucEeOl3XdMbuYL1,F1pjUrsuO8UOwtjgXcIsEd" IsFeedback="true" />
+            <Link Id="Kqwcd7Qemf9PIzxRC8xckR" Ids="Klz0bMfWkyaPxnxDiqGrpY,LbqdpAnucEeOl3XdMbuYL1" />
+            <Link Id="A3bZRtGa9bWOtsR6S45Ixe" Ids="LbqdpAnucEeOl3XdMbuYL1,HDsSay3nwUxMb4Fjoi1ePp" />
+            <Link Id="Df9JYWGcdKkL1QxI4GXzp8" Ids="Ivui4jrhqR4NNiEORgFtHk,F1pjUrsuO8UOwtjgXcIsEd" />
+            <Link Id="DzSUw0Cdy44QdmQNsiI5z1" Ids="F1pjUrsuO8UOwtjgXcIsEd,VBqOCM7BKKQP7yOaPeTuSN" />
+            <Link Id="PfLHdGi6oaOL7ZRB0AfODj" Ids="NzsLnnyWIBbOC1U9TrZp4q,DITyS6shaktPaWHj7cb5DP" />
+            <Link Id="ECZ5pb8d3FAN78AGYGNBUq" Ids="DITyS6shaktPaWHj7cb5DP,CnYYXQV7U42QUckXMKJO7j" />
+            <Link Id="U8QOwBHKMAUOjYtReFRwLA" Ids="AY9uvt8yJkXOOKmkZ0uhvf,KTbPjNglWzYL0oqcYU8F5f" />
+            <Link Id="Tnq1GlOky3SMhEi7iknLmX" Ids="TdVdcLQRsQmPIyaDsyhFd3,Kxqf8eVLRNgLQeDoORxdqA" />
+            <Link Id="MudJIKvWLS6OtAiEgj65xE" Ids="IrM3q43QLNAMKlp3LzD6bB,MA9zjcNCndmM7QyzWGUzAA" />
+            <Link Id="IC4rW9l1sCYOHmfvCRHOrz" Ids="TTOlo9lFNUzOIyQDi86vr9,H1DblVE3QaZLwJrrWgTKFs" IsHidden="true" />
+            <Link Id="IXymneJVZxcMhwnrTQ0ZXC" Ids="KEscYD5n0WzM3QFNOWq2tx,TTOlo9lFNUzOIyQDi86vr9" />
+            <Link Id="JbyhtiU0cPQMcTGhzWdVmu" Ids="Kxo0P986V5UN1kpbOFetm5,GIWvIy4DUNiPUxhspGcjJT" />
+            <Link Id="T7JU1nqHwTmNQ5gdWEYx18" Ids="TRRI1whBMgILZsekpYV0lp,AY9uvt8yJkXOOKmkZ0uhvf" />
+            <Link Id="UvxARzGIMElMonB4FRoMwX" Ids="LWfb4mesLcZPvXlC5UxDkT,HcgGGaU29KRMfkYXrEWHq1" />
+            <Link Id="ITbJMQQLV9AOzh75EeP1e9" Ids="AEV3l5JkTkyMQaAUYTBYHY,Rh6TPq6DKnhOgOyzWr4UzQ" />
+            <Link Id="LYouMjzWxJvQI0GKiCyFUf" Ids="AhdbJZLCmWZOIDvkxZIdVA,UCU17iaC0s5QDXldldih98" />
+            <Link Id="KmoCRKXb5wuOdDTA9pnKli" Ids="Kz29DuAjiJxLw2HZzzqgRw,SIEGajfJOVzQTU4cYFh6Oq" />
+            <Link Id="CqIMAa2g5FGM4qMHLjmpEt" Ids="C4PC4uGuXDJLqZNWjx0l8J,CzFJrtyfyoLMaHcC7sEifJ" />
+            <Link Id="N03vBbv3a66L4GYXLeO63u" Ids="SIEGajfJOVzQTU4cYFh6Oq,VN7WxK8MyAhQdmtqCKVwhx" />
+            <Link Id="MhXzCicBMO0LDgDPDBkiCe" Ids="IprvRQmIRp3Mff6Iuj6wTt,V4Ih6a8LuFxNylplV73xF2" />
+            <Link Id="RRcvzqT4D03Ma0BSnCanGZ" Ids="UCU17iaC0s5QDXldldih98,ETTMvSWft0SNY0yWVA9ttU" />
+            <Link Id="G3GYvjcOjplMyrCRQs69dV" Ids="Tqz5lYDzjzHNZ45JjmeyFW,OQgnn745E4JLwLOjCM9vHZ" />
+            <Link Id="PQJaBR7GOWiMPYClYcLAn5" Ids="OQgnn745E4JLwLOjCM9vHZ,MR0WZUezhoPQCSKaVLv46D" />
+            <Link Id="JOfKWHKTso9NBWdbDQoPiA" Ids="Ar8wWAtdqZrLnFOl9n8shg,BWZnOtWow1rLpJqgcbOWVr" />
+            <Link Id="UaIVWq9sNkmO41NzfvHY6r" Ids="KEscYD5n0WzM3QFNOWq2tx,HRCyXHooE2FLAIWXn3hHJK" />
+            <Link Id="Q6Bbvo0dqADOB8jCFsYo1U" Ids="CpDBGsFzPT0MkuVRT4S2dC,K4KW4NkreOkNR8BV0IINgq" />
+            <Link Id="MIUwoauSCVaPOjTPOE0PEB" Ids="CpDBGsFzPT0MkuVRT4S2dC,Fa52iRKCzzqPbs36EJeNpk" />
+            <Link Id="DCfxSPXqODYOyeP7NOFKYI" Ids="Q160VSJCO37NtUD288m8zK,BhHtLvEUtnhMcQDVevXtLI" />
+            <Link Id="Mn1MMFUHieTMmuTv2Lv9ja" Ids="Kl51l54LPNfLMZtnNoMw5e,LeP22HbB2hpMHHOkRto7NQ" IsFeedback="true" />
+            <Link Id="STrbI7Gxe05OlfnRM0VXuq" Ids="HxA2oGoIld1OaYT82MX1L7,LeP22HbB2hpMHHOkRto7NQ" />
+            <Link Id="SOfqGgaXJsRQFppBPsBsq5" Ids="LeP22HbB2hpMHHOkRto7NQ,OF620sci4mKOL1TIdh5onE" />
+            <Link Id="Q5jZhuk1AsHP2h4tX9HatP" Ids="TRRI1whBMgILZsekpYV0lp,Um7fh5eF6pVP3enKJKLSft" />
+            <Link Id="S9F5FKCUSMTN671kEnlG40" Ids="KoL14pEnY79NaPwRYbLU8y,NlTsVBIYEJqMdwF49f2IS1" />
+            <Link Id="LkVB4hrSJCpMpQG92oCmkn" Ids="Um7fh5eF6pVP3enKJKLSft,QFB9KwlW4X5Myx1R0A096q" />
+            <Link Id="RU3ObzHht45O76Y7iEPhle" Ids="PVHWIyMhheOMAuVunW48Cb,PoBObeTgjGZLKjzb3GMdmp" />
+            <Link Id="FHypKViLdsDLDxklDdKqzn" Ids="HdAQ3G9QEkvLAZuJI7pzh5,F76NwnV837YMVkY3ld24UL" />
+            <Link Id="AYef0OtTHAuMdtVrwBYKeN" Ids="AlB26iVgJz6NWUlsOoA3sI,QN4JKdVOiCLO2EAxr9sjJi" />
+            <Link Id="IpQAQgkO1wJNbvTZYyQ5Bp" Ids="GMTsqiiotBvMxg5TntqbaE,A9ts0unFJXOLFlj8uXL6tp" />
+            <Link Id="DEoeBTWhz22NSKs2Mh1X1c" Ids="NCYoX06VQ03P8hxTdi453c,E9If2LFOlmCQcXeNb9n8ya" IsFeedback="true" />
+            <Link Id="BW2xGpihvbGQb0mIsOK8bs" Ids="H4REWyeL739MdMqsFWdGJU,E9If2LFOlmCQcXeNb9n8ya" />
+            <Link Id="MGAf1ddZa0eQRIEP2fCNs3" Ids="FkTPuZQ17yHOArSymm0zmx,OZ6PTwxJ3SJMvYx5kZp9wb" IsFeedback="true" />
+            <Link Id="UY7zi78ZTvEQSxCUs700Vg" Ids="E9If2LFOlmCQcXeNb9n8ya,OZ6PTwxJ3SJMvYx5kZp9wb" />
+            <Link Id="BQ6itdefWimOk04TbAZzI1" Ids="OZ6PTwxJ3SJMvYx5kZp9wb,Fn5cOKd4zlyMSzuwIpLomU" />
+            <Link Id="IhPSlpNgLdlQFQLHCGTQYk" Ids="LFhxIesZ1gCPpLRB6QHfns,C0rePlwzJrwMz5JJ6u7Dry" />
+            <Link Id="TuKE8eqJAwIMKgZ5vMKBL9" Ids="BBIg5siPju1LShYdRGBglp,DKwRBOq9oQRLtiU4dHp0Sb" />
+            <Link Id="CpWOVMEXQLOL0QpsHEQqi0" Ids="JXJj5RW4FtTLdsFJzeNczx,FYehU8nX8TNOY6wp1kS9FC" />
+            <Link Id="Hjhqo4asCIMOeEoqBeeFDF" Ids="Bzi6yTWXfEEPWFbngX9xWs,OiyPHyp9G8BMkBnYIKleTV" />
+            <Link Id="K9RtYXmQiqNLjxQU1JIjaT" Ids="PcFNk1bRVo7Priklx16g5b,ES8Fx3vTaPAPtGu3fcYYkz" />
+            <Link Id="MT6iewVo6gJOsfWINIX77W" Ids="S3DJKs8Y35ZLdg716NiHr0,HQHiJF6QcMoPVLUsd6UueH" />
+            <Link Id="OILo0TeraLRLfhAEtS5FVT" Ids="HV178qBqgwuQCnGIZxf7gd,HFqleKocsmHORoi7btmVVz" />
+            <Link Id="PJRulstfK8EMjEHbIE8gzc" Ids="VrzEubzJmbdP4PeuJ1vZkl,Sw9yIGiS7vkOmWZ5kex90N" />
+            <Link Id="HMGJtBPRkLKMoyRuQ5aHDK" Ids="FfDg5E3U4cUOdjWNxiHOBu,IKyBJyxvb0wQaBD4Ode4mR" />
+            <Link Id="PPm3ncfK5ALMBf3Np19ObH" Ids="V665FcKCms8PWGxdY5nJm1,SpMSwmMs50kLOFtWUaMN5a" />
+            <Link Id="LIvxbBLeqwhPqvRwOk7RVb" Ids="HFGS8Mth36cQKPbSCowmBt,HcIzBmdAu0gO4TJ7VJ2a1Y" IsFeedback="true" />
+            <Link Id="FbPSRNNowqtPiFYh6qPX4l" Ids="BEZarwAysvIMspuy0deuyk,HcIzBmdAu0gO4TJ7VJ2a1Y" />
+            <Link Id="OMa3MeJ1J3iN4cvmZpMCpz" Ids="HcIzBmdAu0gO4TJ7VJ2a1Y,H4REWyeL739MdMqsFWdGJU" />
+            <Link Id="Jy4wO42GCz7LXU55R0xZuI" Ids="Eg4HiBDb1RlNQk5tA0azWI,HFGS8Mth36cQKPbSCowmBt" />
+            <Link Id="VYIxiGHomBFM6aT6KQIps0" Ids="PKENBr3mOamNL6flnn2uMn,Ib3zh3ecq4vMjDX2xS9wuA" />
+            <Link Id="P5Y7rGQnmOLMx1Rr6JiLjI" Ids="PUTEWOGkEqTPW26GwgQthl,IAMUHl2NVcYNwArhFlBj3I" />
+            <Link Id="QRtsic2hFgeNMOpQsn48hN" Ids="AnZxI6OnIA9QGhgAX8KJCV,MF4SFGcMTt4L1DSGJRcag3,T4ItbGGaSg1QKmNYYks85Q" />
+            <Link Id="BEpHfwmuOHoNfg9vqpm6BK" Ids="VADAJm3qfRQMOM1mwltHIK,Cz0S2CnsCgrPgFQf3E6FLm" />
+            <Link Id="SA1K4Hk9A9HNuEf2KVOJkh" Ids="I0g2MNpsm6ZNFifBoRUF0z,UdzsLL4EI3PMPvYvCc63e2" />
+          </Patch>
+        </Node>
       </Canvas>
     </Canvas>
     <!--
@@ -3284,4 +2458,7 @@
   <PlatformDependency Id="VGH9llAHCJmNy4pJgTdPAV" Location="Stride.Core.dll" />
   <PlatformDependency Id="K1G9BZxPZ4iNNuMWUkVu6h" Location="Stride.Core.dll" />
   <PlatformDependency Id="VxYuIWclHNzNWp9QVtdcv4" Location="Stride.Core.dll" />
+  <PlatformDependency Id="AXcdw9WeG1DQQgyFOhuG94" Location="Stride.Engine.dll" />
+  <PlatformDependency Id="E6mFjRfTJHBMOO2YPSBqql" Location="Stride.Rendering.dll" />
+  <PlatformDependency Id="OJC3O2zC4pfP0DXXMd2J8y" Location="Stride.Rendering.dll" />
 </Document>

--- a/VL.ShadowCatcher.vl
+++ b/VL.ShadowCatcher.vl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PMvFqWqqs1yLAVbmX0v45S" LanguageVersion="2023.5.0" Version="0.128">
-  <NugetDependency Id="FLSt9h7XMOdP0rpAwkKKWN" Location="VL.CoreLib" Version="2023.5.0" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="PMvFqWqqs1yLAVbmX0v45S" LanguageVersion="2023.5.2" Version="0.128">
+  <NugetDependency Id="FLSt9h7XMOdP0rpAwkKKWN" Location="VL.CoreLib" Version="2023.5.2" />
   <Patch Id="DNfGMPEryrQMEAdBnh05hI">
     <Canvas Id="EOi0XkRdXSvL66Ap5PM9WU" DefaultCategory="ShadowCatcher" CanvasType="FullCategory">
       <!--
@@ -1305,28 +1305,6 @@
               <Pin Id="CxV6GLXBD0VN2gDakC1t1l" Name="Output" Kind="StateOutputPin" />
               <Pin Id="RUDDJDxN6V6L79SYMzO4AI" Name="Count" Kind="OutputPin" />
             </Node>
-            <Node Bounds="-75,2675,81,19" Id="TSI1TN6kFhZLxTRZkJPmFR">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="TextureQueue" />
-              </p:NodeReference>
-              <Pin Id="EwjsffMo3dGOjI9MaeIdwn" Name="Input" Kind="InputPin" />
-              <Pin Id="Gi0Xee7wv2PMmvzZFybNcM" Name="Frame Count" Kind="InputPin" DefaultValue="2" />
-              <Pin Id="ECL1uYn6FKnNRKA0tLuZN3" Name="Clear" Kind="InputPin" />
-              <Pin Id="N4qvdFEUVmCPdrHYofvU0U" Name="Insert" Kind="InputPin" />
-              <Pin Id="ClybueASnxiNSStmwQbtAu" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="-70,2720,52,19" Id="IWTclS62SlcLHTxCh4kxBb">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="GetSlice" />
-              </p:NodeReference>
-              <Pin Id="PppEkDNXvHpP4WbVhXvJIu" Name="Input" Kind="StateInputPin" />
-              <Pin Id="JKZlpzsM9vqLoxQgYZK7Bb" Name="Default Value" Kind="InputPin" />
-              <Pin Id="Svro9YVq8dZNdKbkKQGpKo" Name="Index" Kind="InputPin" DefaultValue="0" />
-              <Pin Id="CJ7us4ScrqzQPbg6yYotqG" Name="Result" Kind="OutputPin" />
-            </Node>
             <Pad Id="Cm4CcKYY89WLdKiIeh7Ko7" Comment="Spot Light Count" Bounds="681,3154,35,15" ShowValueBox="true" isIOBox="true" Value="2">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
@@ -1581,15 +1559,6 @@
               <Pin Id="RGloaS7Psp5NZqFZMU5eBR" Name="Output" Kind="OutputPin" />
               <Pin Id="LqGVV8kCrAvLVeREaH7jCx" Name="Has Changed" Kind="OutputPin" />
             </Node>
-            <Pad Id="NpN1TN4xJjRPgKUwdhgc31" Bounds="14,2695,220,40" ShowValueBox="true" isIOBox="true" Value="Delay one frame to align timing with other shadow parameters">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-              <p:ValueBoxSettings>
-                <p:fontsize p:Type="Int32">9</p:fontsize>
-                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-              </p:ValueBoxSettings>
-            </Pad>
             <Pad Id="Ujb1lhhWjgBM0ZcqwUM9j7" Comment="Point Light Count" Bounds="753,3190,35,15" ShowValueBox="true" isIOBox="true" Value="0">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
@@ -1713,6 +1682,7 @@
               <Pin Id="IIlPtyWYOQTNVCs73ssDSM" Name="Output" Kind="OutputPin" />
               <Pin Id="SssEBaUbezONH5zoDxRkni" Name="Has Changed" Kind="OutputPin" />
             </Node>
+            <ControlPoint Id="Io86YvtdaUHOGaPvThTSiA" Bounds="-106,2761" />
           </Canvas>
           <ProcessDefinition Id="J8T83TqnngoMIIuhIdPJqZ">
             <Fragment Id="RJB3hwPu0yaM7LHx3CBlel" Patch="THBwAFOt8a4N12lYwcnrXd" Enabled="true" />
@@ -1780,8 +1750,6 @@
           <Link Id="ERcBadc0MXEMp2fPrsFyCW" Ids="LRUeRw3YZk3Px0UFx1Ek9m,IwC0eUs243CNS4kRvfv3qg" />
           <Link Id="OjndDxqXe9AMN2e27V7gYS" Ids="LjDRNtL4rvwOd7uv0or3H1,SrxqFV3xEoAPAnAXoFmi72" />
           <Link Id="JSIw3yOYRBhNMzs3n2GHkD" Ids="SeGEWP1HjQlOBy1zYU1owo,GYc01OWlGGEOLic4ZPoGQA" />
-          <Link Id="J2L7YDHN76hPVJWcmlS85i" Ids="Jtx4uK1IGYIOoFJUp9nve7,EwjsffMo3dGOjI9MaeIdwn" />
-          <Link Id="VQwviySipslNTn5zbKMs6d" Ids="ClybueASnxiNSStmwQbtAu,PppEkDNXvHpP4WbVhXvJIu" />
           <Link Id="PfV91nmCuaSMdruTppZydz" Ids="RUDDJDxN6V6L79SYMzO4AI,Cm4CcKYY89WLdKiIeh7Ko7" />
           <Link Id="JbcIwjEF5HBLnisuKcsVAN" Ids="Kbt2Q8t4cqfN5AkxBfstRn,HrWO5lH8ApmLIez808Mze3" />
           <Link Id="SagF1jhsyi3OzPuVofHWDX" Ids="PYzbslezMMLN4RcIr74Qyb,Q6f4Aj5SQJ2LagU8jdz6CI" />
@@ -1840,7 +1808,6 @@
           <Link Id="UIODcBxdS3eMPsIyaVYFqF" Ids="AHPikePdeKZLrtpyXYWuan,DzKZQCxakA5OgnEMjNJwgi" />
           <Link Id="AAOCLK0k2T3PQGQmwFuI0j" Ids="Jx9otizf3yWN1UsjqSXJwa,L7Ojq1AxwbkP7t6a05kD0N" />
           <Link Id="BwUXJL5lJN1Ov0dBbvJoZN" Ids="VHmTl8JaMx2PWpRKzEysKe,HSKnAA40iBmMypWquosjiz" />
-          <Link Id="Es8iditUlW1PCKgWa3zTZR" Ids="CJ7us4ScrqzQPbg6yYotqG,Fv4TZILVb6GPGrZNlr5izW" />
           <Link Id="IXxCvwSxN4sPVtNf9VGYHk" Ids="Ujb1lhhWjgBM0ZcqwUM9j7,TbtnfD4ljnMNxNJjL8mvaY" />
           <Link Id="Equgt5Lo0QAPn5ZpMdSCmH" Ids="SKbiApyNJrbLYqmNkkmyjY,Ujb1lhhWjgBM0ZcqwUM9j7" />
           <Link Id="ToUEJyekihBPtb4DOLW0Oy" Ids="I4ny1mKiZkdLwRxBoehOFA,QdXQuy4GNa2OEdYSIruB47" />
@@ -1921,6 +1888,7 @@
           <Link Id="MIWvr7OirtBL5zU9tFXKX1" Ids="KffoUwPCvbfPgq5bwzkGys,OKRIM6pUMJ7Pd9roAJ1q9p" />
           <Link Id="RL5UTUKbDA2NwLPFk2kN5j" Ids="BqIkiLYKOHSNrUeXUVCbDL,IxTkhy30MywO0EYmy3Ys1g" />
           <Link Id="OzLGHlH9uxOL3CqUOMbzLJ" Ids="EU3346LPwhVO8tvs0R2zSi,CbbA8LYJ0XJN2mtcR5shBv" />
+          <Link Id="VO2KDmQ2F1MLxlqINlXFlg" Ids="Jtx4uK1IGYIOoFJUp9nve7,Io86YvtdaUHOGaPvThTSiA,Fv4TZILVb6GPGrZNlr5izW" />
         </Patch>
       </Node>
       <!--
@@ -1934,56 +1902,7 @@
         </p:NodeReference>
         <Patch Id="NhQUm5U58nLLIfFbdpubeS">
           <Canvas Id="TGNklbSH9OhM4EJKQNyrwO" CanvasType="Group">
-            <Node Bounds="597,783,525,19" Id="DgAHJyaAZ0nMsQul22FQ6Y">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
-              </p:NodeReference>
-              <Pin Id="LXdrO8HiPNMMvxblCPxGXh" Name="Shadow Map Texture" Kind="InputPin" />
-              <Pin Id="Pwr7ERkSrW1PEnm8iQab6f" Name="World To Shadow Cascade UV" Kind="InputPin" />
-              <Pin Id="JdVMjE2MdGmPTJThyKsQBb" Name="Depth Biases" Kind="InputPin" />
-              <Pin Id="SnvLtT1ZPdfMad6ixKdtZ4" Name="Offset Scales" Kind="InputPin" />
-              <Pin Id="GuT7PgKvUOtOs8XNtYZeD6" Name="Light Positions" Kind="InputPin" />
-              <Pin Id="S1AHbGcWyguOUxAqgLXizX" Name="Atten Params" Kind="InputPin" />
-              <Pin Id="K4wEg143JELNAeTw2UmNUb" Name="Filter Size" Kind="InputPin" />
-              <Pin Id="UZHPnV6yehfLd6eQWOsEsX" Name="Cascade Depth Splits" Kind="InputPin" />
-              <Pin Id="NsNfDYBmZ88N0hkRxILABu" Name="Spot Directions" Kind="InputPin" />
-              <Pin Id="HBv6VV020Z0QEuw7hGgZy6" Name="Depth Parameters" Kind="InputPin" />
-              <Pin Id="LxI1HzfnV3RLI6pVKQ5iBA" Name="Shadow Map Texture Size" Kind="InputPin" />
-              <Pin Id="EyK6Eo3qZ0lP6WxRFXFhtS" Name="Shadow Map Texture Texel Size" Kind="InputPin" />
-              <Pin Id="EOT62xmCFWtMyATXez26sH" Name="Directional Count" Kind="InputPin" />
-              <Pin Id="LYUYcGw4lJHLvCX6QzZQxw" Name="Spot Light Count" Kind="InputPin" />
-              <Pin Id="MYzxI9Cp64bLiHqzLRAxya" Name="Point Light Count" Kind="InputPin" />
-              <Pin Id="QLLT7yUX1ICMHezCYFx5gA" Name="Cascade Count" Kind="InputPin" />
-              <Pin Id="OhxD9GSad8CM3CC3esYEBk" Name="Light Attenuation" Kind="InputPin" />
-              <Pin Id="IYZWxQsw1xULdkfN9lfbRi" Name="Shadow Texture" Kind="InputPin" />
-              <Pin Id="B6julGolArLOSAmHztCWMj" Name="Other Texture" Kind="InputPin" />
-              <Pin Id="GiuCxWFkNaSNKISUiErdl4" Name="Linear Sampler" Kind="InputPin" />
-              <Pin Id="UlOYzZgkyg5Nvg1dWvRCiP" Name="Linear Clamp Compare Less Equal Sampler" Kind="InputPin" />
-              <Pin Id="TurujKBeDr2OonXJsGy4ft" Name="Shadow Tint" Kind="InputPin" />
-              <Pin Id="Jgj48GzHcr2M5F9ZzTH2bH" Name="Other Tint" Kind="InputPin" />
-              <Pin Id="NG0USab4VDKQYQj1NUG9mo" Name="Normal Offset" Kind="InputPin" />
-              <Pin Id="Ff9yDc06WqOPS2A4YGvlzA" Name="World" Kind="InputPin" />
-              <Pin Id="JEf5vaZGQ8nPA25s4XvLvI" Name="Parameter Setter" Kind="InputPin" />
-              <Pin Id="GBNx5659KUdLdYu4i3xTph" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="660,977,165,19" Id="GCISEKXwL3VQDoGt8CFiNd">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
-              </p:NodeReference>
-              <Pin Id="JZIsmalFemtPLmHh0C0Ikb" Name="Effect Instance" Kind="InputPin" />
-              <Pin Id="SZO3If3OYyyMAfRi0MZl6d" Name="Blend State" Kind="InputPin" />
-              <Pin Id="CRqi902aim0OCm27vOFqoW" Name="Rasterizer State" Kind="InputPin" />
-              <Pin Id="Th7Y3zOd7Y2PMZLFQ6lahF" Name="Depth Stencil State" Kind="InputPin" />
-              <Pin Id="AIKXRJ5i665OWPpafJ4vFt" Name="Mesh" Kind="InputPin" />
-              <Pin Id="GirOQPRAL9jLhtC3WrUEui" Name="Instance Count" Kind="InputPin" />
-              <Pin Id="LBWP3509oNNPtH3JLW8HZ9" Name="Profiling Name" Kind="InputPin" DefaultValue="Shadow Catcher" />
-              <Pin Id="TJenrQ2qQC3LExBiTAj6if" Name="Topology" Kind="InputPin" />
-              <Pin Id="OccuUB9iC4RQJ0pzNy9W7S" Name="Draw Count" Kind="InputPin" />
-              <Pin Id="L6b8LqybzPRPX7usAPjQs4" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="671,1071,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
+            <Node Bounds="1032,1122,165,19" Id="UJdDE8unIrcOj1lZRsChvO">
               <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
@@ -1999,116 +1918,17 @@
               <Pin Id="ChfH4QpRGwHLciNOwh20Oy" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="PsNo2ehteioPThgMNATyIa" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="665,898,67,19" Id="I4FAhFoJWEmOFvkj2IBsah">
-              <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="AlphaBlend" />
-              </p:NodeReference>
-              <Pin Id="OiKnGW1d0shPoP17tDHr5L" Name="Alpha Blend" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="633,547,46,19" Id="IyA4nxuTBiYMnyia6ixVYH">
-              <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
-              </p:NodeReference>
-              <Pin Id="M9DuRd96RijMIrLf1Hykk7" Name="X" Kind="InputPin" />
-              <Pin Id="AOaBgMQtSiuOrYEGbjvfnF" Name="Y" Kind="InputPin" />
-              <Pin Id="UDuUF5jhGclM7P6DgBylXb" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="661,597,25,19" Id="DbUlhef6e8sQDPDo2f988d">
-              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="/" />
-              </p:NodeReference>
-              <Pin Id="L02bHNVM7oZNFy05KcbCxD" Name="Input" Kind="InputPin" DefaultValue="1, 1" />
-              <Pin Id="QMfEPP9CnMgPYwrK3ZGtw7" Name="Input 2" Kind="InputPin" />
-              <Pin Id="G1ABsRYsM8KPiE1tHN8j4J" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="470,627,165,19" Id="OjTRCgxnr9FNwBe8zSUWbd">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Decons" />
-              </p:NodeReference>
-              <Pin Id="CY8C2MGl06vNz3tJmaDqfa" Name="Input" Kind="StateInputPin" />
-              <Pin Id="N5k074n17LrLttHfKIW6D5" Name="Result" Kind="OutputPin" />
-              <Pin Id="U2zLf16Ph94NrFESYr0o98" Name="Result 2" Kind="OutputPin" />
-              <Pin Id="NtHRY5myXbtNXmURHWPAsk" Name="Result 3" Kind="OutputPin" />
-              <Pin Id="AIgJDqrLkaONSMjvXBK5Ue" Name="Result 4" Kind="OutputPin" />
-              <Pin Id="UHOO6nsf3hGNWh7dRgrDJJ" Name="Result 5" Kind="OutputPin" />
-              <Pin Id="S9EyN1PAa7NPZjJkTFXUNr" Name="Result 6" Kind="OutputPin" />
-              <Pin Id="L9ukhAgjMMAPIlLVKSHXk4" Name="Result 7" Kind="OutputPin" />
-              <Pin Id="LZamEdTC3UNOL33w2Cdw0R" Name="Result 8" Kind="OutputPin" />
-              <Pin Id="Q4bhyaIzlxuNSK3BfgYXYV" Name="Result 9" Kind="OutputPin" />
-            </Node>
-            <Pad Id="GGYIPMJR3I1MZnPhAkIOlN" Comment="Cascade Count" Bounds="759,644,35,15" ShowValueBox="true" isIOBox="true" Value="4">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="HwscKIVZENNM6aHdKWSBrx" Bounds="437,198" />
-            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="826,938" />
-            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="1037,707" />
+            <ControlPoint Id="LggpBjjKIo1QZDfUO6hOMP" Bounds="884,869" />
+            <ControlPoint Id="UaTz3i1SmtDLLbxftJz0Xa" Bounds="1044,864" />
             <ControlPoint Id="UzGUFmF6msIMa5xFfwYVvs" Bounds="585,1236" />
-            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="1286,745" />
-            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="854,1051" />
-            <Node Bounds="435,252,414,26" Id="HfHLZKluYWxL9GZIgoIaFq">
-              <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Split" />
-              </p:NodeReference>
-              <Pin Id="G8IHgpF1YtALIOyBX12zLf" Name="Input" Kind="StateInputPin" />
-              <Pin Id="OMwkEUqOHvUQTVt3N0F6io" Name="Output" Kind="OutputPin" />
-              <Pin Id="DlAsxh5eEKFNJoB2BPiY6K" Name="ShadowMap" Kind="OutputPin" />
-              <Pin Id="UVTUrpDNeaiMwvXetPSvrs" Name="Buffers" Kind="OutputPin" />
-              <Pin Id="CscHkdbS7aPP7HG9qR18mv" Name="Directional Light Count" Kind="OutputPin" />
-              <Pin Id="Nlx4svqScr5NETl9REihzk" Name="Spot Light Count" Kind="OutputPin" />
-              <Pin Id="Cgr6BvGeDWSOPzqXn8Adto" Name="Point Light Count" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="378,376,80,80" Id="TW21N9564SxMLYf8UydRmz">
-              <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
-                <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AvoidNull" />
-              </p:NodeReference>
-              <Pin Id="E9N4gJe4RhCOSM8xTS0IWQ" Name="Input" Kind="InputPin" />
-              <Pin Id="PMyuvdLo5cLQKT1bQnqqJn" Name="Output" Kind="OutputPin" />
-              <Patch Id="ObVgMZW6E0oO9UXCyr1OdK" Name="Create Default Value" ManuallySortedPins="true">
-                <Pin Id="K3Bi609n5ojQIerUjhpOXS" Name="Result" Kind="OutputPin" />
-                <ControlPoint Id="M1bLTuV0yFZLwUJQMjT16L" Bounds="395,427" />
-              </Patch>
-            </Node>
-            <Node Bounds="394,340,106,19" Id="U7sUUMjZBR3LUBhntuNdxf">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
-              </p:NodeReference>
-              <Pin Id="H2YMtw2vafvPWcQcM22dhf" Name="Size" Kind="InputPin" DefaultValue="4, 4" />
-              <Pin Id="Von6YwCke48PpY86qiQAgg" Name="Format" Kind="InputPin" />
-              <Pin Id="KC3EpeQIbGsNLk5DUClH1H" Name="Recreate" Kind="InputPin" />
-              <Pin Id="DPt1iU8vGrAOksjJXBvt5s" Name="Output" Kind="OutputPin" />
-              <Pin Id="Qbi9TaW83k4N6aZm6zgeRk" Name="Has Changed" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="378,479,44,26" Id="UKjNgfVDyG1NBXj6J2W7fD">
-              <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Category" Name="Texture" />
-                <Choice Kind="OperationCallFlag" Name="Width" />
-              </p:NodeReference>
-              <Pin Id="GV1EcwPjowpOO3x6Z2Pw3Q" Name="Input" Kind="StateInputPin" />
-              <Pin Id="AyNYTehgFhlLEfc0qS7Zmk" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="SEzoPXakqNYPKFOsgukg4K" Name="Width" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="DA6h5rwBNC6LAYYfmSnpOd" Bounds="381,300" />
-            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="992,482" />
-            <Pad Id="QsVP4LdMemMOdVYurFDgKb" Comment="Width" Bounds="633,519,35,15" ShowValueBox="true" isIOBox="true" />
-            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="769,1010" />
-            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="816,1030" />
-            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="789,912" />
-            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="765,885" />
-            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="1199,715" />
+            <ControlPoint Id="GgjVEl7nWXCPnQJ6TxD9b6" Bounds="843,743" />
+            <ControlPoint Id="SZVFmNc3cixPKmrIMS3n3f" Bounds="1215,1102" />
+            <ControlPoint Id="RKwBZOlI7RoO4Va0RvLEzQ" Bounds="922,763" />
+            <ControlPoint Id="LfLGDNWACf6PcPyU7yvx2z" Bounds="1130,1061" />
+            <ControlPoint Id="Hc1pgHC7wbTM0t4pTVw0NG" Bounds="1177,1081" />
+            <ControlPoint Id="JnaZIUEH7aNObphuZ3JKMr" Bounds="1219,869" />
+            <ControlPoint Id="Tl2VLbOAbt9Lj5moWfAY6E" Bounds="1240,898" />
+            <ControlPoint Id="IwGjrVhVfsdO0lcfiFVwOl" Bounds="962,795" />
             <Node Bounds="583,1173,85,19" Id="Iv8QmhFRdfxO0nnglV0UEB">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -2147,7 +1967,7 @@
               <Pin Id="CUAksSoURmoNEvLtxSOCuh" Name="Cull Mode" Kind="InputPin" />
               <Pin Id="H32bPBTM1KfMeVYKMBofja" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="561,973,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
+            <Node Bounds="567,971,65,19" Id="FPwhbdUTGMEOMm0Wy35dwM">
               <p:NodeReference LastCategoryFullName="Stride.Materials.MiscAttributes.Transparency" LastDependency="VL.Stride.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Transparency" NeedsToBeDirectParent="true" />
@@ -2159,18 +1979,18 @@
               <Pin Id="Mt9TDjWb1AKO9dCzjiKKEA" Name="Enabled" Kind="InputPin" DefaultValue="True" />
               <Pin Id="FwtCYbbNCR2QGPh7hPEGWZ" Name="Output" Kind="OutputPin" />
             </Node>
-            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="576,901,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
+            <Pad Id="El6kUPGmZvrNWcVPmYvzsF" Comment="Tint" Bounds="589,899,35,57" ShowValueBox="true" isIOBox="true" Value="0, 0, 0, 0">
               <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector4" />
               </p:TypeAnnotation>
             </Pad>
             <ControlPoint Id="NTiYitJLiPJOA7OZ6tjgMv" Bounds="512,959" />
-            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="552,874,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+            <Pad Id="J7GhQxEIBH5NAimkJJnCHZ" Comment="Alpha" Bounds="568,849,35,15" ShowValueBox="true" isIOBox="true" Value="0">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="CMpzKF371B5Pc0s5lxnUKK" Bounds="332,1063,144,58" ShowValueBox="true" isIOBox="true" Value="For updating render view frustum used by Directional light">
+            <Pad Id="CMpzKF371B5Pc0s5lxnUKK" Bounds="325,1063,144,58" ShowValueBox="true" isIOBox="true" Value="For updating render view frustum used by Directional light">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
@@ -2179,95 +1999,36 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="1181,663" />
-            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="1202,467" />
-            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="1035,519" />
-            <Node Bounds="1121,361,113,19" Id="RYZJWgjArzMOqXDzWA5ANa">
-              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
+            <ControlPoint Id="R7aGpGSYqLbNeQQWpOuxpX" Bounds="1163,824" />
+            <ControlPoint Id="P8JoFcxamPGLWPZ6AjuSsH" Bounds="1150,786" />
+            <ControlPoint Id="FVv0P1PWUCVLVTPWyPbROo" Bounds="1008,837" />
+            <Node Bounds="1052,1007,188,19" Id="VvamwIIbEbCL1iB2OsvFHP">
+              <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ImmutableTexture2D" />
+                <Choice Kind="ProcessAppFlag" Name="ShadowCatcherDataRetrieverRenderer" />
               </p:NodeReference>
-              <Pin Id="HFNhuyzpSaNOdAIZkJcXVx" Name="Initial Data" Kind="InputPin" />
-              <Pin Id="TFEiQjyooI9LZ40fP5HXO5" Name="Size" Kind="InputPin" />
-              <Pin Id="B2llsBN6l3AOYWuhFIfhnF" Name="Format" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm" />
-              <Pin Id="SAIMOSMV4x4L1pshlUtL3z" Name="Recreate On Inital Data Change" Kind="InputPin" />
-              <Pin Id="FtEBKoSk7mjQYmfC036ZIV" Name="Recreate" Kind="InputPin" />
-              <Pin Id="Du63rPkyARXQHZiesn1lFC" Name="Output" Kind="OutputPin" />
-              <Pin Id="RObMUFB3IzRO6ENFwFqfAk" Name="Has Changed" Kind="OutputPin" />
+              <Pin Id="UGLWhvLAFVJPej7ukTOgKR" Name="Input" Kind="InputPin" />
+              <Pin Id="JxJ1R64brF2NynIWOxbJ2l" Name="Compositor" Kind="InputPin" />
+              <Pin Id="CbiESkhbWwXMJsm4gpo4aj" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="SxXmFl9BczbLw7l6gnBmZh" Comment="Size" Bounds="1183,314,35,28" ShowValueBox="true" isIOBox="true" Value="4, 4">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="Int2" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="1117,217,65,19" Id="Q1WT9uFNLuJL6mmuOPOMxl">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+            <Node Bounds="837,941,388,19" Id="UR5kT7mqBX9N5uwowJxlBp">
+              <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Cons" />
+                <Choice Kind="ProcessAppFlag" Name="ShadowCatcherRenderer" />
               </p:NodeReference>
-              <Pin Id="U9zPOvFYBrjPEzvJ9k4jIZ" Name="Input" Kind="InputPin" />
-              <Pin Id="RrpDuM3LEfYLNp5bobIrjS" Name="Input 2" Kind="InputPin" />
-              <Pin Id="PfpKHUuBLc8NHzrydwFV8Y" Name="Result" Kind="OutputPin" />
-              <Pin Id="ArY9NG6jeiEMNSeUMVugmn" Name="Input 3" Kind="InputPin" />
-              <Pin Id="Iw9eNXEeUBLN5uK2VXmLIc" Name="Input 4" Kind="InputPin" />
+              <Pin Id="J9hp6ot0OkiLCiL4pk1lyL" Name="Transformation" Kind="InputPin" />
+              <Pin Id="OdLONk91QdUPzwtSBen7Mk" Name="Mesh" Kind="InputPin" />
+              <Pin Id="RWf5ekrTlQ8Lyaf6zIIdoV" Name="Light Attenuation" Kind="InputPin" />
+              <Pin Id="NDURo8ABoPOLNvwVPgEIt2" Name="Normal Offset" Kind="InputPin" />
+              <Pin Id="HRnJGX2UMiBOrahbE9rSS7" Name="Shadow Texture" Kind="InputPin" />
+              <Pin Id="AF4m6Ho1x6CLiCcpGmWieo" Name="Shadow Tint" Kind="InputPin" />
+              <Pin Id="RbJgbBsGtJ8MI2E5RLU4Pn" Name="Other Texture" Kind="InputPin" />
+              <Pin Id="BSTt5yUZY9sMIHpzjcFGEX" Name="Other Tint" Kind="InputPin" />
+              <Pin Id="LRcSB76aiU4OtbaMvR87LW" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="Lt63z2kVv7nLEdrnarVzvF" Name="Depth Stencil State" Kind="InputPin" />
+              <Pin Id="GbjzedfO4jTOfxZxje0Tyu" Name="Rasterizer State" Kind="InputPin" />
             </Node>
-            <Node Bounds="1137,175,22,19" Id="Sna0ZVAdCzuNvDRDpSPOmA">
-              <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="~" />
-              </p:NodeReference>
-              <Pin Id="Q3w8leMtsTsO7hpCeLWVD4" Name="Input" Kind="StateInputPin" />
-              <Pin Id="QJZCXLbI0O8MZ5v6op4LI1" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="1118,259,65,19" Id="JkhqVKZy8iWPut5Bk9YIcJ">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Cons" />
-              </p:NodeReference>
-              <Pin Id="UpukU6f0PxgLsaXYBKcG7N" Name="Input" Kind="InputPin" />
-              <Pin Id="ISsVMsJCIsBOu7rrXhqzsu" Name="Input 2" Kind="InputPin" />
-              <Pin Id="Qp71Oe7I6TQQIlpsIryzb4" Name="Result" Kind="OutputPin" />
-              <Pin Id="OpVgHR9caJaPfL0XRE8GAa" Name="Input 3" Kind="InputPin" />
-              <Pin Id="KCVkXTZp1kSLjUMUvh9hLA" Name="Input 4" Kind="InputPin" />
-            </Node>
-            <Node Bounds="1118,300,47,19" Id="FPZyWdQEIWVLPirbbDceM2">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="Flatten" />
-              </p:NodeReference>
-              <Pin Id="Vac6eb6k7TlOangvr5UWAT" Name="Input" Kind="StateInputPin" />
-              <Pin Id="I641PNlObJmMzzDTDzsu8z" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <ControlPoint Id="Rs7eAx8iil0OpPInfjpSHB" Bounds="1136,390" />
-            <Pad Id="FkTT3wZK7krPlF6grhkQza" SlotId="Uc2SOuq6BXlPdHh1yHCQWm" Bounds="1136,432" />
-            <Node Bounds="1034,555,96,110" Id="BWduDgxct4QMowLmmHnuNr">
-              <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
-                <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AvoidNull" />
-              </p:NodeReference>
-              <Pin Id="JpowceVqpFqP71jRcyuz7i" Name="Input" Kind="InputPin" />
-              <Pin Id="JpAsz9bLpEuMVvRvWy2qwi" Name="Output" Kind="OutputPin" />
-              <Patch Id="EOTcbOcKLC2O3vfA04enw0" Name="Create Default Value" ManuallySortedPins="true">
-                <Pin Id="U1C2OI4sJOmLyr21JSkTJc" Name="Result" Kind="OutputPin" />
-                <ControlPoint Id="SJTNQhEEgqdPxdmWcAyDRa" Bounds="1050,635" />
-              </Patch>
-            </Node>
-            <Node Bounds="1204,503,96,110" Id="H2Ff1UdDunmQLUQObqVmXu">
-              <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
-                <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AvoidNull" />
-              </p:NodeReference>
-              <Pin Id="TL8pYEUOXVHO35jVavD3TI" Name="Input" Kind="InputPin" />
-              <Pin Id="P9D4DvF4EwjPRQvnOl7r9d" Name="Output" Kind="OutputPin" />
-              <Patch Id="S0gmGQYvAsfLuwA22zM9bu" Name="Create Default Value" ManuallySortedPins="true">
-                <Pin Id="TKgtrMzUca1Mlv472nFnxY" Name="Result" Kind="OutputPin" />
-                <ControlPoint Id="QDrZbYAwywiLeuwBGHhqhW" Bounds="1220,583" />
-              </Patch>
-            </Node>
+            <ControlPoint Id="F3AyyIyfEfSMG2XbgFzicM" Bounds="1316,923" />
           </Canvas>
           <ProcessDefinition Id="OYIyatA91KLOCZaTdgqMhW">
             <Fragment Id="AM3gkuf1OjILQKsjuNe11b" Patch="TZOUr2B4xdnNuWwnWeWSzU" Enabled="true" />
@@ -2278,42 +2039,16 @@
             <Fragment Id="EOimgwSQhdZPdQMqaUJFLz" Patch="UNsRMl4kijJPry95Vg8qFS" Enabled="true" />
             <Fragment Id="IkHgT3lafBzMtI84OaTteK" Patch="JCtSBF3jE2nOOgcqxCeUYv" Enabled="true" />
           </ProcessDefinition>
-          <Link Id="CAzUFwDJdLJP8JLBx8uUvy" Ids="UDuUF5jhGclM7P6DgBylXb,QMfEPP9CnMgPYwrK3ZGtw7" />
-          <Link Id="QWS3ACKKceBOop7WagoCVN" Ids="UDuUF5jhGclM7P6DgBylXb,LxI1HzfnV3RLI6pVKQ5iBA" />
-          <Link Id="SxdPplhgbC2Ope2rdTdWQ0" Ids="G1ABsRYsM8KPiE1tHN8j4J,EyK6Eo3qZ0lP6WxRFXFhtS" />
-          <Link Id="DklxrnWtgKLLYRGi1xY5Ns" Ids="N5k074n17LrLttHfKIW6D5,Pwr7ERkSrW1PEnm8iQab6f" />
-          <Link Id="Ifj0qPlVud7LCUitPuflqu" Ids="U2zLf16Ph94NrFESYr0o98,JdVMjE2MdGmPTJThyKsQBb" />
-          <Link Id="IFBZiBHc9cYMOch3qnatSO" Ids="NtHRY5myXbtNXmURHWPAsk,SnvLtT1ZPdfMad6ixKdtZ4" />
-          <Link Id="ErYK7OLkKOyOKn8vpTejZC" Ids="GGYIPMJR3I1MZnPhAkIOlN,QLLT7yUX1ICMHezCYFx5gA" />
-          <Link Id="F0j9ATd2RcANfIFofJ2xen" Ids="O22TM09IJz6NJKs2mfBD9m,HwscKIVZENNM6aHdKWSBrx" IsHidden="true" />
-          <Link Id="DpDYpC9v3prOE6g4HJpUPw" Ids="LggpBjjKIo1QZDfUO6hOMP,AIKXRJ5i665OWPpafJ4vFt" />
           <Link Id="TSktX25J5jlLmG9Z7DsWMS" Ids="UUSfYs5XCFrOQJCIzUOlWm,LggpBjjKIo1QZDfUO6hOMP" IsHidden="true" />
           <Link Id="Pbek9028MHtOJwXSUCv62n" Ids="MDtmmxDKQwqNotAB9zH6Qg,UaTz3i1SmtDLLbxftJz0Xa" IsHidden="true" />
           <Link Id="Azq2svpFn6cN6jBagr9xm6" Ids="UzGUFmF6msIMa5xFfwYVvs,GDsQ4yX8w6vON5JYyXcvOw" IsHidden="true" />
           <Link Id="BX6FNFVx0KgPqfJAZd125D" Ids="Hl2dW5WoWo9MuGR7kgzay8,GgjVEl7nWXCPnQJ6TxD9b6" IsHidden="true" />
           <Link Id="StNq0gakutqMQdXFYsRLj4" Ids="SZVFmNc3cixPKmrIMS3n3f,ChfH4QpRGwHLciNOwh20Oy" />
           <Link Id="FPG668M192qNTezc536qfv" Ids="VvUJIhN2gmQLlNMD6zvOfP,SZVFmNc3cixPKmrIMS3n3f" IsHidden="true" />
-          <Link Id="GO2wGZdW8DjMi0CciYr4S0" Ids="GgjVEl7nWXCPnQJ6TxD9b6,Ff9yDc06WqOPS2A4YGvlzA" />
-          <Link Id="R4IS6b12Gm9POYktdR2xxc" Ids="L6b8LqybzPRPX7usAPjQs4,P80IxqYAC4oMO8PVlgw9NK" />
-          <Link Id="T3gzqjSp4DuPeyqHC8BSEt" Ids="GBNx5659KUdLdYu4i3xTph,JZIsmalFemtPLmHh0C0Ikb" />
-          <Link Id="ANYWLHiGjH5L51jqnjo4cl" Ids="HwscKIVZENNM6aHdKWSBrx,G8IHgpF1YtALIOyBX12zLf" />
-          <Link Id="CUwUW0d2SYMLjOGO3ixA3M" Ids="M1bLTuV0yFZLwUJQMjT16L,K3Bi609n5ojQIerUjhpOXS" IsHidden="true" />
-          <Link Id="OyItZnbU93UNMrfa2TbKwE" Ids="DlAsxh5eEKFNJoB2BPiY6K,DA6h5rwBNC6LAYYfmSnpOd,E9N4gJe4RhCOSM8xTS0IWQ" />
-          <Link Id="HivJRRYEkwbN9dXHzeZEWx" Ids="DPt1iU8vGrAOksjJXBvt5s,M1bLTuV0yFZLwUJQMjT16L" />
-          <Link Id="BUnKJVUAzKwLKc5v42Gktg" Ids="UVTUrpDNeaiMwvXetPSvrs,CY8C2MGl06vNz3tJmaDqfa" />
-          <Link Id="CTqMz6FpNOnOtmGiJ4j5NB" Ids="CscHkdbS7aPP7HG9qR18mv,EOT62xmCFWtMyATXez26sH" />
-          <Link Id="VEaERM89pU2OHyxPGmevso" Ids="Nlx4svqScr5NETl9REihzk,LYUYcGw4lJHLvCX6QzZQxw" />
-          <Link Id="QPUOKIgRk84Mp6GZp50RUV" Ids="PMyuvdLo5cLQKT1bQnqqJn,GV1EcwPjowpOO3x6Z2Pw3Q" />
-          <Link Id="RJYaTLBtDmBNSr7LMP9PCg" Ids="OiKnGW1d0shPoP17tDHr5L,SZO3If3OYyyMAfRi0MZl6d" />
-          <Link Id="Te8FK2zyGFhNWCTKoWUCI3" Ids="AIgJDqrLkaONSMjvXBK5Ue,GuT7PgKvUOtOs8XNtYZeD6" />
-          <Link Id="MIGemJnvMkLOsZonNhcy8c" Ids="Cgr6BvGeDWSOPzqXn8Adto,MYzxI9Cp64bLiHqzLRAxya" />
-          <Link Id="Oy4F4959xg8NO92qVHDxZP" Ids="AyNYTehgFhlLEfc0qS7Zmk,LXdrO8HiPNMMvxblCPxGXh" />
-          <Link Id="NrtL1FVRThcPWph6R7Butx" Ids="UHOO6nsf3hGNWh7dRgrDJJ,S1AHbGcWyguOUxAqgLXizX" />
           <Link Id="QZKB6WHjGS7MMTnZSpE6NK" Ids="Oeo1AhRQHFBO8BoUgNRPIw,RKwBZOlI7RoO4Va0RvLEzQ" IsHidden="true" />
-          <Patch Id="TZOUr2B4xdnNuWwnWeWSzU" Name="Create" ParticipatingElements="Sfk8DRUz7dQOgerVilZ2Pj" />
+          <Patch Id="TZOUr2B4xdnNuWwnWeWSzU" Name="Create" />
           <Patch Id="FrW1vDKXOiJOaypDlvgECQ" Name="Update" ManuallySortedPins="true">
             <Pin Id="Hl2dW5WoWo9MuGR7kgzay8" Name="Transformation" Kind="InputPin" Bounds="324,566" />
-            <Pin Id="O22TM09IJz6NJKs2mfBD9m" Name="ShadowCatcher Data" Kind="InputPin" Bounds="471,440" />
             <Pin Id="UUSfYs5XCFrOQJCIzUOlWm" Name="Mesh" Kind="InputPin" Bounds="760,474" />
             <Pin Id="Oeo1AhRQHFBO8BoUgNRPIw" Name="Light Attenuation" Kind="InputPin" Bounds="1012,495" DefaultValue="True">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -2326,14 +2061,8 @@
             <Pin Id="T3rbnwZPaOkP0kSl9KxT0L" Name="Other Tint" Kind="InputPin" Bounds="1052,592" Visibility="Optional" />
             <Pin Id="F9Ch2ryYDJNOnFZL439Qpz" Name="Normal Offset" Kind="InputPin" Bounds="1002,557" Visibility="Optional" />
             <Pin Id="GDsQ4yX8w6vON5JYyXcvOw" Name="Output" Kind="OutputPin" Bounds="678,988" />
+            <Pin Id="EnYU4v26HOdOF1EtcmUIFZ" Name="Compositor" Kind="InputPin" Bounds="1316,923" />
           </Patch>
-          <Link Id="MAdcEYSCbYCPl71NrdEzkp" Ids="S9EyN1PAa7NPZjJkTFXUNr,K4wEg143JELNAeTw2UmNUb" />
-          <Link Id="O4C2F1pxJKWNaMwWIgK8Uv" Ids="L9ukhAgjMMAPIlLVKSHXk4,UZHPnV6yehfLd6eQWOsEsX" />
-          <Link Id="BHxk1dvCD8wPmH87Sk1p1j" Ids="LZamEdTC3UNOL33w2Cdw0R,NsNfDYBmZ88N0hkRxILABu" />
-          <Link Id="F67y7oRI7PiOZGBDD259Ph" Ids="Q4bhyaIzlxuNSK3BfgYXYV,HBv6VV020Z0QEuw7hGgZy6" />
-          <Link Id="IvP7GbH1j3ELFD9gY1N6OW" Ids="SEzoPXakqNYPKFOsgukg4K,QsVP4LdMemMOdVYurFDgKb" />
-          <Link Id="L7dYxfOJVpQK9Zx8CPay7O" Ids="QsVP4LdMemMOdVYurFDgKb,M9DuRd96RijMIrLf1Hykk7" />
-          <Link Id="UKLrCTSKsE1OR2AFNTjs5o" Ids="QsVP4LdMemMOdVYurFDgKb,AOaBgMQtSiuOrYEGbjvfnF" />
           <Link Id="KqkNeRJD7QrMBeLCBrQkO6" Ids="LfLGDNWACf6PcPyU7yvx2z,RokwtKJiuMtMoOdpj0PJmw" />
           <Link Id="BlR4dKYjCstQTtMA8zR1OB" Ids="IQ23JtO0pmQPBFLwLOgKfh,LfLGDNWACf6PcPyU7yvx2z" IsHidden="true" />
           <Patch Id="LddebEmLTTeOeVPULuJ4Rq" Name="SetComponents">
@@ -2348,7 +2077,6 @@
           <Patch Id="De3KvKqZ1AXQdOV80Yt9BO" Name="SetDepthStencilState">
             <Pin Id="PfltMoGTR4kLBDCHKwdBMM" Name="Depth Stencil State" Kind="InputPin" Visibility="Optional" />
           </Patch>
-          <Link Id="FKmwHjFLdWhPVcrZlcfUs8" Ids="Tl2VLbOAbt9Lj5moWfAY6E,CRqi902aim0OCm27vOFqoW" />
           <Link Id="L407F4iDZdcNeWouwrDJyc" Ids="GDf245yfPIPMFa0yANWqgX,Tl2VLbOAbt9Lj5moWfAY6E" IsHidden="true" />
           <Patch Id="UNsRMl4kijJPry95Vg8qFS" Name="SetRasterizerState">
             <Pin Id="GDf245yfPIPMFa0yANWqgX" Name="Rasterizer State" Kind="InputPin" Visibility="Optional" />
@@ -2356,10 +2084,7 @@
           <Patch Id="JCtSBF3jE2nOOgcqxCeUYv" Name="SetEnable">
             <Pin Id="VvUJIhN2gmQLlNMD6zvOfP" Name="Enabled" Kind="InputPin" />
           </Patch>
-          <Link Id="QODL4eVN8j7O3J1XBIJGBJ" Ids="RKwBZOlI7RoO4Va0RvLEzQ,OhxD9GSad8CM3CC3esYEBk" />
-          <Link Id="TVnzb6y79pgQIBUrKRSNeP" Ids="IwGjrVhVfsdO0lcfiFVwOl,NG0USab4VDKQYQj1NUG9mo" />
           <Link Id="E0Tdq8v4VFJPRGTGherQuA" Ids="F9Ch2ryYDJNOnFZL439Qpz,IwGjrVhVfsdO0lcfiFVwOl" IsHidden="true" />
-          <Link Id="V609N0qQ3QtL8apbvwjnS6" Ids="JnaZIUEH7aNObphuZ3JKMr,Th7Y3zOd7Y2PMZLFQ6lahF" />
           <Link Id="FxRYiO7bJ8KNXoB4pZKhw1" Ids="PsNo2ehteioPThgMNATyIa,RwXCUSK1YuPPuYySbTJE3n" />
           <Link Id="ALMHthg3DywOWsZsUtH9O1" Ids="SgsBvnIOFTsMKZaLXrSStk,UzGUFmF6msIMa5xFfwYVvs" />
           <Link Id="T70XvcleV5HQZqm880BA20" Ids="LggpBjjKIo1QZDfUO6hOMP,NTiYitJLiPJOA7OZ6tjgMv,OMebjSEg2RSQWjWtQSFGYc" />
@@ -2369,32 +2094,23 @@
           <Link Id="RrSLfS8lygtQIU40lj7awQ" Ids="El6kUPGmZvrNWcVPmYvzsF,MARcWOXn1azO0C3HiNuPMz" />
           <Link Id="TZZ69NU9L6UNyzZqA9KSra" Ids="J7GhQxEIBH5NAimkJJnCHZ,TntVHPdCyWGPtIb6vPd8Pj" />
           <Link Id="KvASiOn1yk6PFGlCzBzmh6" Ids="VkXlqC4dIcDMGE8ZPvANY1,StdEHp814oAQaqbT7jSo6H" />
-          <Link Id="TUMJl9kCZz3Lb7cXXCiCB0" Ids="UaTz3i1SmtDLLbxftJz0Xa,TurujKBeDr2OonXJsGy4ft" />
-          <Link Id="EH5neapVmIfNoxkRNd1h9a" Ids="R7aGpGSYqLbNeQQWpOuxpX,Jgj48GzHcr2M5F9ZzTH2bH" />
           <Link Id="CSMJ3P9bU4VNQB37OVVxMV" Ids="T3rbnwZPaOkP0kSl9KxT0L,R7aGpGSYqLbNeQQWpOuxpX" IsHidden="true" />
           <Link Id="FgGBUdYnB6RL46HaKWq66P" Ids="UTu4QWqp0w5NITxk4Tisq2,P8JoFcxamPGLWPZ6AjuSsH" IsHidden="true" />
           <Link Id="IcWU9d3ykViOVSBm3nrjph" Ids="UoV2be0ImCxP6OJw4wQYQW,FVv0P1PWUCVLVTPWyPbROo" IsHidden="true" />
-          <Link Id="LQLlXBvNXiMNtO5CUrwtM8" Ids="SxXmFl9BczbLw7l6gnBmZh,TFEiQjyooI9LZ40fP5HXO5" />
-          <Link Id="KGsnSsWE20WMribrLCJ15A" Ids="QJZCXLbI0O8MZ5v6op4LI1,U9zPOvFYBrjPEzvJ9k4jIZ" />
-          <Link Id="CQ6geMgFNh9OjFw4ncnwc6" Ids="QJZCXLbI0O8MZ5v6op4LI1,RrpDuM3LEfYLNp5bobIrjS" />
-          <Link Id="M0LH9feIxtWMmIouuF66a4" Ids="QJZCXLbI0O8MZ5v6op4LI1,ArY9NG6jeiEMNSeUMVugmn" />
-          <Link Id="A35Z8TXrYjzOVQs0V0fka7" Ids="QJZCXLbI0O8MZ5v6op4LI1,Iw9eNXEeUBLN5uK2VXmLIc" />
-          <Link Id="EMytmTlthJKOhY5FaWCvqs" Ids="PfpKHUuBLc8NHzrydwFV8Y,UpukU6f0PxgLsaXYBKcG7N" />
-          <Link Id="C8G6vr1f84POanFpJhC6aX" Ids="PfpKHUuBLc8NHzrydwFV8Y,ISsVMsJCIsBOu7rrXhqzsu" />
-          <Link Id="QktGe5fCYTNOkRVPCKI3qG" Ids="PfpKHUuBLc8NHzrydwFV8Y,OpVgHR9caJaPfL0XRE8GAa" />
-          <Link Id="KVltxV6ssd4NN94hX69PuZ" Ids="PfpKHUuBLc8NHzrydwFV8Y,KCVkXTZp1kSLjUMUvh9hLA" />
-          <Link Id="LosIkpuNyM7NkuDcLWo13A" Ids="Qp71Oe7I6TQQIlpsIryzb4,Vac6eb6k7TlOangvr5UWAT" />
-          <Link Id="DemZGcSTiwQMPyF3FDr70H" Ids="I641PNlObJmMzzDTDzsu8z,HFNhuyzpSaNOdAIZkJcXVx" />
-          <Slot Id="Uc2SOuq6BXlPdHh1yHCQWm" Name="Default" />
-          <Link Id="Sfk8DRUz7dQOgerVilZ2Pj" Ids="Du63rPkyARXQHZiesn1lFC,Rs7eAx8iil0OpPInfjpSHB,FkTT3wZK7krPlF6grhkQza" />
-          <Link Id="GoM0PpPsXoQMQ9irGEphv4" Ids="SJTNQhEEgqdPxdmWcAyDRa,U1C2OI4sJOmLyr21JSkTJc" IsHidden="true" />
-          <Link Id="NFGciBLM4f4P7PWXN7O8Xd" Ids="FVv0P1PWUCVLVTPWyPbROo,JpowceVqpFqP71jRcyuz7i" />
-          <Link Id="TOOkxH9W3UQNymDaAKwoU1" Ids="FkTT3wZK7krPlF6grhkQza,SJTNQhEEgqdPxdmWcAyDRa" />
-          <Link Id="VQalZ3wLVrANcewPqgDxLX" Ids="JpAsz9bLpEuMVvRvWy2qwi,IYZWxQsw1xULdkfN9lfbRi" />
-          <Link Id="EcqhuaW2ObbMrc2SeERzKo" Ids="QDrZbYAwywiLeuwBGHhqhW,TKgtrMzUca1Mlv472nFnxY" IsHidden="true" />
-          <Link Id="TWXEYf9ReikMZfZOgeTGpx" Ids="P8JoFcxamPGLWPZ6AjuSsH,TL8pYEUOXVHO35jVavD3TI" />
-          <Link Id="E70crku6b37OfuNKCzYmLf" Ids="FkTT3wZK7krPlF6grhkQza,QDrZbYAwywiLeuwBGHhqhW" />
-          <Link Id="IYaAD1velKgMzyl6LQhiTq" Ids="P9D4DvF4EwjPRQvnOl7r9d,B6julGolArLOSAmHztCWMj" />
+          <Link Id="SQvQyFgeZtNQFUx9NQVHxI" Ids="CbiESkhbWwXMJsm4gpo4aj,P80IxqYAC4oMO8PVlgw9NK" />
+          <Link Id="I25cdjctTb4NwXljtMCYeM" Ids="LRcSB76aiU4OtbaMvR87LW,UGLWhvLAFVJPej7ukTOgKR" />
+          <Link Id="CAl3KN6MstOL7zHQsXpT3Y" Ids="LggpBjjKIo1QZDfUO6hOMP,OdLONk91QdUPzwtSBen7Mk" />
+          <Link Id="Ja6w1jAQanIMBwwDVzQ1t6" Ids="F3AyyIyfEfSMG2XbgFzicM,JxJ1R64brF2NynIWOxbJ2l" />
+          <Link Id="TKPVjUiV5uFQUbsFP6qRZW" Ids="EnYU4v26HOdOF1EtcmUIFZ,F3AyyIyfEfSMG2XbgFzicM" IsHidden="true" />
+          <Link Id="J5XzBkqHYdyP4FbgYSAUxA" Ids="RKwBZOlI7RoO4Va0RvLEzQ,RWf5ekrTlQ8Lyaf6zIIdoV" />
+          <Link Id="F5q4Jg1UfP1L1sRA8sBIpm" Ids="IwGjrVhVfsdO0lcfiFVwOl,NDURo8ABoPOLNvwVPgEIt2" />
+          <Link Id="VvpVIs1IzOGQL2zuiQPYBJ" Ids="FVv0P1PWUCVLVTPWyPbROo,HRnJGX2UMiBOrahbE9rSS7" />
+          <Link Id="DCnDiilsE72LDoIOUNR0gN" Ids="UaTz3i1SmtDLLbxftJz0Xa,AF4m6Ho1x6CLiCcpGmWieo" />
+          <Link Id="J5uss81NXjIQCb541RbyPD" Ids="P8JoFcxamPGLWPZ6AjuSsH,RbJgbBsGtJ8MI2E5RLU4Pn" />
+          <Link Id="R18H9zPQ1jwOIKvL9oEC9A" Ids="Tl2VLbOAbt9Lj5moWfAY6E,GbjzedfO4jTOfxZxje0Tyu" />
+          <Link Id="ATDRD1cHn3rPLCtBmfgzwU" Ids="JnaZIUEH7aNObphuZ3JKMr,Lt63z2kVv7nLEdrnarVzvF" />
+          <Link Id="N85bCRGQmtNQECLdAZ9Ijl" Ids="R7aGpGSYqLbNeQQWpOuxpX,BSTt5yUZY9sMIHpzjcFGEX" />
+          <Link Id="NmAPGVWtavpQKqQ5cMCAqZ" Ids="GgjVEl7nWXCPnQJ6TxD9b6,J9hp6ot0OkiLCiL4pk1lyL" />
         </Patch>
       </Node>
       <!--
@@ -2614,7 +2330,7 @@
     ************************ ShadowCatcherData ************************
 
 -->
-        <Node Name="ShadowCatcherData" Bounds="525,576" Id="KV9rSIBGCeVOcnA8cejlMC">
+        <Node Name="ShadowCatcherData" Bounds="525,551" Id="KV9rSIBGCeVOcnA8cejlMC">
           <p:NodeReference>
             <Choice Kind="ClassDefinition" Name="Class" />
             <CategoryReference Kind="Category" Name="Primitive" />
@@ -2636,10 +2352,15 @@
               <ControlPoint Id="AzTKUzYO00vOtGtHB7LCqS" Bounds="541,626" />
               <ControlPoint Id="KVstnVcLKtuOu7Hg7io30C" Bounds="693,628" />
               <ControlPoint Id="LTSMTZMxgMANhRdT83mWEa" Bounds="818,653" />
+              <Pad Id="VUUETggZwSsL3mjUDPmprS" SlotId="J5qK8SZcxU0MTZhnWtfMPl" Bounds="1075,532" />
+              <ControlPoint Id="Imbgq97QLldO2KIJ940lte" Bounds="1075,446" />
+              <ControlPoint Id="L1FK9i52oX5PzA3iWVbZFd" Bounds="1075,593" />
             </Canvas>
             <ProcessDefinition Id="LzPrAzJE31JLKafIeeuD4X" IsHidden="true">
               <Fragment Id="OA03ttXEMPEMa0w1Cm85Y3" Patch="P6biVyzuArgNVQRSpxn9yD" Enabled="true" />
               <Fragment Id="TKCxBwQmhRRNwzN8cFqael" Patch="Mtck473ObVkMmf5vqxSrrl" />
+              <Fragment Id="Oi11GLf2e1fLADlglKUbAk" Patch="De4Spoj8NjFNYYdFF4MAKP" />
+              <Fragment Id="Clwx7ZRPCveOWudz2YHVOE" Patch="C0Q8WkTvaEpOhyi3NWmGUU" />
             </ProcessDefinition>
             <Link Id="F3S7knzYAE7QV5z8fUmCgx" Ids="P02uXztTRq8MtSG03flbpC,Jbhikcq27cpNZv0LDsC0ub" IsHidden="true" />
             <Link Id="MDVGXAW0hyoQVCWKJPPASY" Ids="MvjKKPVwimYQS5xoS4syG8,SxRoFSoHCcqM6El1HHNG67" IsHidden="true" />
@@ -2705,6 +2426,21 @@
               <Pin Id="Fq4apYRFUojOKD77L4Ca9s" Name="Spot Light Count" Kind="OutputPin" />
               <Pin Id="Sx1WnD29HR8P253ap1cBTV" Name="Point Light Count" Kind="OutputPin" />
             </Patch>
+            <Slot Id="J5qK8SZcxU0MTZhnWtfMPl" Name="Frame Number">
+              <p:TypeAnnotation p:Type="TypeReference">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Slot>
+            <Link Id="TJOWBB1B2QtOJpSI3U8m4f" Ids="Imbgq97QLldO2KIJ940lte,VUUETggZwSsL3mjUDPmprS" />
+            <Link Id="OkiklNHIr9JMuBnCZEArhY" Ids="Gu9USXVJVJhNu9bwUfgmWV,Imbgq97QLldO2KIJ940lte" IsHidden="true" />
+            <Patch Id="De4Spoj8NjFNYYdFF4MAKP" Name="SetFrameNumber">
+              <Pin Id="Gu9USXVJVJhNu9bwUfgmWV" Name="Frame Number" Kind="InputPin" />
+            </Patch>
+            <Link Id="Ionz2eq2aG1PXmgSVnXXed" Ids="VUUETggZwSsL3mjUDPmprS,L1FK9i52oX5PzA3iWVbZFd" />
+            <Link Id="DdfOi6WhiVOMxqnbRKDSIL" Ids="L1FK9i52oX5PzA3iWVbZFd,Ts4kCWEtdmNOLweSqWN15p" IsHidden="true" />
+            <Patch Id="C0Q8WkTvaEpOhyi3NWmGUU" Name="GetFrameNumber">
+              <Pin Id="Ts4kCWEtdmNOLweSqWN15p" Name="Frame Number" Kind="OutputPin" />
+            </Patch>
           </Patch>
         </Node>
         <!--
@@ -2712,7 +2448,7 @@
     ************************ ShadowCatcherRenderer ************************
 
 -->
-        <Node Name="ShadowCatcherRenderer" Bounds="527,662" Id="MKIwYc0GMvhM1Xi97B8Ofx">
+        <Node Name="ShadowCatcherRenderer" Bounds="525,780" Id="MKIwYc0GMvhM1Xi97B8Ofx">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="ClassDefinition" Name="Class" />
           </p:NodeReference>
@@ -2723,158 +2459,8 @@
           </p:Interfaces>
           <Patch Id="QejBHbOpLTJOuzZIrA4NNY">
             <Canvas Id="LLYUbQWfLcmPsoyV9K3uVm" CanvasType="Group">
-              <ControlPoint Id="JmyUN95v58lQDkwdKK7ZxQ" Bounds="742,651" />
-              <Node Bounds="1326,975,425,19" Id="HiRC7axjnA7POHvVuRF9BX">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
-                </p:NodeReference>
-                <Pin Id="LjRcLyRYjQTL6r2G72U1Dx" Name="Shadow Map Texture" Kind="InputPin" />
-                <Pin Id="Pmkk6PyrSbTNH1gW8CJpo1" Name="World To Shadow Cascade UV" Kind="InputPin" />
-                <Pin Id="M1eEJ77dUeNLO60zHhtL54" Name="Depth Biases" Kind="InputPin" />
-                <Pin Id="JOd7Yv1YpGELNrmDCV4gkO" Name="Offset Scales" Kind="InputPin" />
-                <Pin Id="MnIrnhAhFEhLfmc9iOtcyz" Name="Light Positions" Kind="InputPin" />
-                <Pin Id="ML895Ub6iwHMn6bY2qWHrC" Name="Atten Params" Kind="InputPin" />
-                <Pin Id="F8JhmocSEZBQPpciz0Gnvp" Name="Filter Size" Kind="InputPin" />
-                <Pin Id="IJkUUH6AV6oNyYyM3wfyLG" Name="Cascade Depth Splits" Kind="InputPin" />
-                <Pin Id="VHFY2zPYpWCNheQDczgdTm" Name="Spot Directions" Kind="InputPin" />
-                <Pin Id="MSgrm4PPCcGPrkethMgFSR" Name="Depth Parameters" Kind="InputPin" />
-                <Pin Id="NvF8gz0v0IYLDQ7gkqwtIM" Name="Shadow Map Texture Size" Kind="InputPin" />
-                <Pin Id="FenyPqc0zkhQQIHwsmTJWp" Name="Shadow Map Texture Texel Size" Kind="InputPin" />
-                <Pin Id="C46kWyP2J4ZPjmm981rMAj" Name="Directional Count" Kind="InputPin" />
-                <Pin Id="UHghVFLFfyCLGyz7aWCD1O" Name="Spot Light Count" Kind="InputPin" />
-                <Pin Id="JgC6MYbxlS1QDdHNbi7qnI" Name="Point Light Count" Kind="InputPin" />
-                <Pin Id="B6WSt3TnXvuO2BChyS63KG" Name="Cascade Count" Kind="InputPin" />
-                <Pin Id="IeIhDGc3Q7zQFT4up5opPS" Name="Light Attenuation" Kind="InputPin" />
-                <Pin Id="LYn95tX8ihVN2Inzz6D3Ca" Name="Linear Clamp Compare Less Equal Sampler" Kind="InputPin" />
-                <Pin Id="Jn4MQIq2375PYWwPp3dQCK" Name="Color Input" Kind="InputPin" />
-                <Pin Id="Qyj9y0GuanDMZvhmuxv0qE" Name="Normal Offset" Kind="InputPin" />
-                <Pin Id="Lebv8mH06wrLu5c14Xg9E8" Name="World" Kind="InputPin" />
-                <Pin Id="CZghCSXIZpMPEgaYLrHp5e" Name="Parameter Setter" Kind="InputPin" />
-                <Pin Id="FydGgPzgtFQMI8PHwIModE" Name="Output" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="1508,1158,165,19" Id="O16OLBOTXc2O9wT6AgeU5L">
-                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
-                </p:NodeReference>
-                <Pin Id="UqLSa6HalcQL1GQmP9UoAo" Name="Effect Instance" Kind="InputPin" />
-                <Pin Id="MxnYiw6f9JDLwlj10swonE" Name="Blend State" Kind="InputPin" />
-                <Pin Id="VZqR9o8TNZgPCS6vWCNmVt" Name="Rasterizer State" Kind="InputPin" />
-                <Pin Id="VbZkiWB0WXvQDRKRAx2DcX" Name="Depth Stencil State" Kind="InputPin" />
-                <Pin Id="JbsV0gC5MRfPbuZHQlGdma" Name="Mesh" Kind="InputPin" />
-                <Pin Id="MFXRzNKSnUnMMuP7imHhdB" Name="Instance Count" Kind="InputPin" />
-                <Pin Id="IwwJ7FLkXDIO9nXOlCQs0I" Name="Profiling Name" Kind="InputPin" DefaultValue="Shadow Catcher" />
-                <Pin Id="M7FFE9A2gvwPu7gCm1yGAy" Name="Topology" Kind="InputPin" />
-                <Pin Id="PyHZeU4vRa2MUxo0cLUmU9" Name="Draw Count" Kind="InputPin" />
-                <Pin Id="A4HO3ad8iuwOGSNse4CpzN" Name="Output" Kind="StateOutputPin" />
-              </Node>
-              <Node Bounds="1528,1063,67,19" Id="HZI66h2CFGJO6KHdbyPnoj">
-                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
-                  <Choice Kind="OperationCallFlag" Name="AlphaBlend" />
-                </p:NodeReference>
-                <Pin Id="EyJOvglCgX4MLBxyCiudK5" Name="Alpha Blend" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="1509,835,46,19" Id="Mf3napswkKxOjB36yyVzgK">
-                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
-                  <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
-                </p:NodeReference>
-                <Pin Id="BjiBk8NXp8HL2hj8ydkah3" Name="X" Kind="InputPin" />
-                <Pin Id="HkwusbOBxEPPHsUPLlB6W4" Name="Y" Kind="InputPin" />
-                <Pin Id="QWaF7FGYuNpL5g5oIvn1lD" Name="Output" Kind="StateOutputPin" />
-              </Node>
-              <Node Bounds="1537,885,25,19" Id="DMZFjfgRhQOL7KoBxIaffo">
-                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="/" />
-                </p:NodeReference>
-                <Pin Id="SPtLlCwHO49OJk18BDwb5K" Name="Input" Kind="InputPin" DefaultValue="1, 1" />
-                <Pin Id="HNJidM6gci3NKD1G9rB5vy" Name="Input 2" Kind="InputPin" />
-                <Pin Id="NHR2FXylqiTN8BvDCvrKcQ" Name="Output" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="1331,908,165,19" Id="EiMrjEfcNZ4NJ8X6Zyhhb5">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
-                  <Choice Kind="OperationCallFlag" Name="Decons" />
-                </p:NodeReference>
-                <Pin Id="VcGjpTTBObDOKYcGzyybau" Name="Input" Kind="StateInputPin" />
-                <Pin Id="S3Bwc27bLxgPYEOP1Q7Ljv" Name="Result" Kind="OutputPin" />
-                <Pin Id="ESh5XkMzKl7M6Eq35hGpb6" Name="Result 2" Kind="OutputPin" />
-                <Pin Id="HSMu4yNkdvJM58B7eGAjbg" Name="Result 3" Kind="OutputPin" />
-                <Pin Id="N4ba85Pr9LyOBHampi4L7u" Name="Result 4" Kind="OutputPin" />
-                <Pin Id="KgclaBeMwdbPWj3NF7TSN5" Name="Result 5" Kind="OutputPin" />
-                <Pin Id="MbevPEfTVHiQEJmaQRQzTc" Name="Result 6" Kind="OutputPin" />
-                <Pin Id="TylSnZ7ElCDNiTNQROZc85" Name="Result 7" Kind="OutputPin" />
-                <Pin Id="UdxrbsIVK34O08hANLhXh7" Name="Result 8" Kind="OutputPin" />
-                <Pin Id="CNnpVviRFLVPLLghhCEE7I" Name="Result 9" Kind="OutputPin" />
-              </Node>
-              <Pad Id="UPRhXxkWLm2LnaT2ThYJ7T" Comment="Cascade Count" Bounds="1724,759,35,15" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Integer32" />
-                </p:TypeAnnotation>
-              </Pad>
-              <ControlPoint Id="GNgJFHqWapoQPIVfRJVXKG" Bounds="2148,968" />
-              <ControlPoint Id="P33MTf6WnozOM7eGhYzilR" Bounds="2004,688" />
-              <ControlPoint Id="KnJ7LEIBAhZNYQIrH10z9G" Bounds="2053,753" />
-              <Node Bounds="1288,522,414,26" Id="OnzPbiWgADvOpmeUJ0iwIk">
-                <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
-                  <Choice Kind="OperationCallFlag" Name="Split" />
-                </p:NodeReference>
-                <Pin Id="S4RmSRix1a2QEzvmU0gCJe" Name="Input" Kind="StateInputPin" />
-                <Pin Id="ImUNHAKmzPkOVSLVP6Lmoz" Name="Output" Kind="OutputPin" />
-                <Pin Id="K9myjgkNuMINrrZf5U7PWd" Name="ShadowMap" Kind="OutputPin" />
-                <Pin Id="AeiWyUQBxrhMEeWH0OiD3Z" Name="Buffers" Kind="OutputPin" />
-                <Pin Id="C1dvIEE1BPNLNdYb9LLfXV" Name="Directional Light Count" Kind="OutputPin" />
-                <Pin Id="DDq9NtmWIibMZimyUepMV5" Name="Spot Light Count" Kind="OutputPin" />
-                <Pin Id="IvG0KdoQ9rGMCfgUN0lZZp" Name="Point Light Count" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="1254,664,80,80" Id="RBYNd2JYYt2OOsi9mZA4vr">
-                <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
-                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="AvoidNull" />
-                </p:NodeReference>
-                <Pin Id="BWHwNwXZv8XLuou0kSbaNq" Name="Input" Kind="InputPin" />
-                <Pin Id="VYRAoytJKcLL0HJXs4Qiza" Name="Output" Kind="OutputPin" />
-                <Patch Id="AJpGJ3rQZRzPEPMd5AwV87" Name="Create Default Value" ManuallySortedPins="true">
-                  <Pin Id="DNSzEhF4osKLfQWAcHXRsp" Name="Result" Kind="OutputPin" />
-                  <ControlPoint Id="ELmLkHRLBD2PdkDWkgt8PD" Bounds="1271,715" />
-                </Patch>
-              </Node>
-              <Node Bounds="1270,628,106,19" Id="TbeLnAI9epEMewgaYlQTyc">
-                <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
-                </p:NodeReference>
-                <Pin Id="S6c3293nwxTLCPZJq7td06" Name="Size" Kind="InputPin" DefaultValue="4, 4" />
-                <Pin Id="Hjhl7jv7TMjPYnEv7t00h4" Name="Format" Kind="InputPin" />
-                <Pin Id="GWUm8coql11PjX5BxbpR2U" Name="Recreate" Kind="InputPin" />
-                <Pin Id="GWfO7Gwma58MbJ7GvPQlMw" Name="Output" Kind="OutputPin" />
-                <Pin Id="IqsR10P6GLoOtN5Tx0YMWa" Name="Has Changed" Kind="OutputPin" />
-              </Node>
-              <Node Bounds="1254,767,44,26" Id="Vwy3lsCZr1mPeAkw8OuXEs">
-                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <CategoryReference Kind="Category" Name="Texture" />
-                  <Choice Kind="OperationCallFlag" Name="Width" />
-                </p:NodeReference>
-                <Pin Id="MIXSTF2wBmTLXbIKJ05UbT" Name="Input" Kind="StateInputPin" />
-                <Pin Id="K76lTijzjZZQRXcbGnQyMk" Name="Output" Kind="StateOutputPin" />
-                <Pin Id="KoGLpmJGmNuMBVCYJqJuOj" Name="Width" Kind="OutputPin" />
-              </Node>
-              <ControlPoint Id="KHWIEvYfRBfQCDhdvjZsy1" Bounds="1257,588" />
-              <ControlPoint Id="I1KCXRFlc56LhwEiPPZp2E" Bounds="1975,652" />
-              <Pad Id="QsDNnDvS7AVQZBcL37Pe5y" Comment="Width" Bounds="1509,807,35,15" ShowValueBox="true" isIOBox="true" />
-              <ControlPoint Id="TUahzGGrtU2MVOcrUXDgvJ" Bounds="2123,947" />
-              <ControlPoint Id="NKbckpPLKfhONKlyJh6FV1" Bounds="2103,931" />
-              <ControlPoint Id="Hm26lRA6GDkPzesjqTsn95" Bounds="2028,721" />
-              <Node Bounds="1509,1377,51,26" Id="DEUUMoIDhvAPsnwDvyKYTm">
+              <ControlPoint Id="JmyUN95v58lQDkwdKK7ZxQ" Bounds="2182,728" />
+              <Node Bounds="2779,1903,51,26" Id="DEUUMoIDhvAPsnwDvyKYTm">
                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
@@ -2884,31 +2470,299 @@
                 <Pin Id="NEO6q6I2i4dPjNnJzhLmGp" Name="Context" Kind="InputPin" />
                 <Pin Id="Tl7wyt0Ir8sN0xW7rB3ris" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="1509,1246,188,19" Id="G8lwX9IFfNoLHDSicinMhq">
+              <Node Bounds="2716,1557,525,19" Id="EFcDZ0rAt8dPKWpoTPVFd8">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering.DrawShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes (C:\Dev\vvvv\vl-libs\VL.ShadowCatcher)">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessNode" Name="ShadowDrawShader" />
+                </p:NodeReference>
+                <Pin Id="FgJiTl3z8eWPB8BG5jhhxN" Name="Shadow Map Texture" Kind="InputPin" />
+                <Pin Id="KpRd5z5MFKzMaUap3cMeLk" Name="World To Shadow Cascade UV" Kind="InputPin" />
+                <Pin Id="Ob9iAtsFyrbN3pxCRcZ518" Name="Depth Biases" Kind="InputPin" />
+                <Pin Id="LZzE02ChVO5OsRZfmPpMpZ" Name="Offset Scales" Kind="InputPin" />
+                <Pin Id="Opu7B03FJbQOEkZr75gjET" Name="Light Positions" Kind="InputPin" />
+                <Pin Id="Kipu41TxSpIN8eE4AxlN68" Name="Atten Params" Kind="InputPin" />
+                <Pin Id="MIOZzirlycsNKPbUh7oIlb" Name="Filter Size" Kind="InputPin" />
+                <Pin Id="NkhB6AocjEhNdcxCKmnnsZ" Name="Cascade Depth Splits" Kind="InputPin" />
+                <Pin Id="BJhxpQDa3umL5ToaQ4UhAh" Name="Spot Directions" Kind="InputPin" />
+                <Pin Id="B1PRP7OylfCN1cnxIHrSkD" Name="Depth Parameters" Kind="InputPin" />
+                <Pin Id="S0dVjZq3snlPxk4WCyhmzl" Name="Shadow Map Texture Size" Kind="InputPin" />
+                <Pin Id="ShdwcUqACAdQQGPvf1HMcs" Name="Shadow Map Texture Texel Size" Kind="InputPin" />
+                <Pin Id="AxNOiJ2PZfSN25Cmu6AMYI" Name="Directional Count" Kind="InputPin" />
+                <Pin Id="E5KCG7xKwLBOi3bIMm75XO" Name="Spot Light Count" Kind="InputPin" />
+                <Pin Id="KOVQSxtgJQYL1VqC6M1Vga" Name="Point Light Count" Kind="InputPin" />
+                <Pin Id="KtzzL5PmE7LMvqBfsV5aq7" Name="Cascade Count" Kind="InputPin" />
+                <Pin Id="MhZIlBa4dDcNL4IByhD4Ii" Name="Light Attenuation" Kind="InputPin" />
+                <Pin Id="AhXS6nuqsF0M5M3JwKm1ux" Name="Shadow Texture" Kind="InputPin" />
+                <Pin Id="P1AvbWgZSRnM8TPnKzhrc9" Name="Other Texture" Kind="InputPin" />
+                <Pin Id="MrbQh89uljZQZ3eEFBUHjm" Name="Linear Sampler" Kind="InputPin" />
+                <Pin Id="MiF563TaxYwOq6zHzdNEOR" Name="Linear Clamp Compare Less Equal Sampler" Kind="InputPin" />
+                <Pin Id="H4NDBUUF7YwLfkHgjf0ybT" Name="Shadow Tint" Kind="InputPin" />
+                <Pin Id="OWHkNVKaYONN7rwAxjDiyA" Name="Other Tint" Kind="InputPin" />
+                <Pin Id="GSzpOV0miiPOFdjcN0B7kE" Name="Normal Offset" Kind="InputPin" />
+                <Pin Id="UjhuQ6fwBhPN9CdC8Zm6la" Name="World" Kind="InputPin" />
+                <Pin Id="AjPi6TruA1UNq43LvfmH86" Name="Parameter Setter" Kind="InputPin" />
+                <Pin Id="T2GnL1RO1RbMbGev2XXN4c" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2780,1718,165,19" Id="MPbnltAUkA7MPFGGEws3ik">
+                <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="MeshRenderer" />
+                </p:NodeReference>
+                <Pin Id="UoSotBsaBNTOPXUOceWYFT" Name="Effect Instance" Kind="InputPin" />
+                <Pin Id="UDZGx9TaENTNv1DpVezrMZ" Name="Blend State" Kind="InputPin" />
+                <Pin Id="SDJHTZJYrCvLtBVu3fXHFd" Name="Rasterizer State" Kind="InputPin" />
+                <Pin Id="JqddSxONwVcMv9ykHwsddR" Name="Depth Stencil State" Kind="InputPin" />
+                <Pin Id="JuXCGJQrqOvNfhcHItbTkc" Name="Mesh" Kind="InputPin" />
+                <Pin Id="NFsoKoPS9B2NfMD381ttal" Name="Instance Count" Kind="InputPin" />
+                <Pin Id="HNWeZy4oPX0PjlV9Yfk3Ag" Name="Profiling Name" Kind="InputPin" DefaultValue="Shadow Catcher" />
+                <Pin Id="E0skTnsHuArQSYlGYKgCTS" Name="Topology" Kind="InputPin" />
+                <Pin Id="SiD2SPlsBXdNJ3kGwQtp6r" Name="Draw Count" Kind="InputPin" />
+                <Pin Id="CT97BEWDhmBPGcVX9NAhPe" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="2799,1615,67,19" Id="Iv8HEMBEvGsNWGUS8jym4D">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.BlendStateDescription" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="BlendStateDescription" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="AlphaBlend" />
+                </p:NodeReference>
+                <Pin Id="BPNLoqDTpPsPxulnDLFLfY" Name="Alpha Blend" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2828,1300,46,19" Id="EybVyj1wtVMPHNl1m880tm">
+                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                </p:NodeReference>
+                <Pin Id="EAokkHryU4oLWA9DiRv0Hc" Name="X" Kind="InputPin" />
+                <Pin Id="TWHULF1KKMTMY03ZRxLN2w" Name="Y" Kind="InputPin" />
+                <Pin Id="EqoiojoXGwtMqwnWThJ1JN" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="2885,1360,25,19" Id="L2u00IR9HlQOjrnWTYmCAw">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="/" />
+                </p:NodeReference>
+                <Pin Id="MX0xfQpOLC9M7iwVX0EbPE" Name="Input" Kind="InputPin" DefaultValue="1, 1" />
+                <Pin Id="Dd3A51t1YAYNi9sJ1eylgM" Name="Input 2" Kind="InputPin" />
+                <Pin Id="R0NYQHJ7xblOD4BN0a7y5I" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2674,1378,165,19" Id="FS2gUWb7P5iOjdVMRu9xEO">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Decons" />
+                </p:NodeReference>
+                <Pin Id="HQXEtZnFhuwL3OmkCSp3pQ" Name="Input" Kind="StateInputPin" />
+                <Pin Id="AeMqXBxV37WLXypr1WqLEW" Name="Result" Kind="OutputPin" />
+                <Pin Id="QjvxBhfZhxfOXb4XWTIf6O" Name="Result 2" Kind="OutputPin" />
+                <Pin Id="FScF16eAHHfMnFBeyjZ9Pu" Name="Result 3" Kind="OutputPin" />
+                <Pin Id="JMHJTMZaDkGMZFeljeNqfS" Name="Result 4" Kind="OutputPin" />
+                <Pin Id="KyIBi6STqN2MGVvAHO2is1" Name="Result 5" Kind="OutputPin" />
+                <Pin Id="BY8Hwzo7aQ2NhLcS1i7k0I" Name="Result 6" Kind="OutputPin" />
+                <Pin Id="DLSFuazRCotMYNAjTKQ597" Name="Result 7" Kind="OutputPin" />
+                <Pin Id="P9AqbHgdvXDNbeIfWDcpvw" Name="Result 8" Kind="OutputPin" />
+                <Pin Id="QamoN9H9dfpPUZdep5WoYS" Name="Result 9" Kind="OutputPin" />
+              </Node>
+              <Pad Id="BZJwQj3XBxQLXPiaZvCthJ" Comment="Cascade Count" Bounds="3027,1156,35,15" ShowValueBox="true" isIOBox="true" Value="4">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pad>
+              <ControlPoint Id="LbsvtNcaHprLWUhzfQ7IlQ" Bounds="2957,1676" />
+              <ControlPoint Id="C2oIF41pTsPPxMvbTp9WMo" Bounds="3207,1440" />
+              <ControlPoint Id="AqthvFRkKa9OjYTX3NJyYF" Bounds="3274,1506" />
+              <Node Bounds="2565,899,414,26" Id="CPU2NT8flMqMxh8e9kipNd">
+                <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="RecordType" Name="ShadowCatcherData" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Split" />
+                </p:NodeReference>
+                <Pin Id="KoJxHMTLb2rMPviivjrifo" Name="Input" Kind="StateInputPin" />
+                <Pin Id="CwzJGXP702nOs5Zb1ozEBV" Name="Output" Kind="OutputPin" />
+                <Pin Id="R3vzXKHfAkVMu9X0GS4gVv" Name="ShadowMap" Kind="OutputPin" />
+                <Pin Id="DQBQB7CF2TBQAZmDuWDeTY" Name="Buffers" Kind="OutputPin" />
+                <Pin Id="P18svlScjFmOv0PFSwDCNh" Name="Directional Light Count" Kind="OutputPin" />
+                <Pin Id="LISx9LVm39jLkRQqQD85Wl" Name="Spot Light Count" Kind="OutputPin" />
+                <Pin Id="IxtKMr32FHmMmxkUZh5Iam" Name="Point Light Count" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2498,1117,80,80" Id="QnUuXtO5fjcNF4sTUKxkpM">
+                <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
+                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="AvoidNull" />
+                </p:NodeReference>
+                <Pin Id="NwDv66IwoglPgRkEEaQn2C" Name="Input" Kind="InputPin" />
+                <Pin Id="B7FhjROgOEXQEpXF6pUKo7" Name="Output" Kind="OutputPin" />
+                <Patch Id="GlQYWXWTzEYN2bF40SucyD" Name="Create Default Value" ManuallySortedPins="true">
+                  <Pin Id="H6ILxGVKFqBP2UwRS5D9WL" Name="Result" Kind="OutputPin" />
+                  <ControlPoint Id="GG50zhylpZCOkQvEW5IPLV" Bounds="2515,1168" />
+                </Patch>
+              </Node>
+              <Node Bounds="2514,1061,106,19" Id="MNPA3DvTbhfO7JYIuwOAFp">
+                <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ComputeTexture2D" />
+                </p:NodeReference>
+                <Pin Id="OkTEgETAACbNDjk7BlEOjo" Name="Size" Kind="InputPin" DefaultValue="4, 4" />
+                <Pin Id="KsL4Dv43vYULZL8YltZVmf" Name="Format" Kind="InputPin" />
+                <Pin Id="RYtNotPETiNOHHezacTyt3" Name="Recreate" Kind="InputPin" />
+                <Pin Id="VCVW5DD47hQNld7JXsn36b" Name="Output" Kind="OutputPin" />
+                <Pin Id="Fl82CqOwHSsL3K6C86eA7m" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2498,1220,44,26" Id="HmXto4qRcVxO0VAGbjWneN">
+                <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Texture" />
+                  <Choice Kind="OperationCallFlag" Name="Width" />
+                </p:NodeReference>
+                <Pin Id="K1AVfqFVKauMyrg2PneWM2" Name="Input" Kind="StateInputPin" />
+                <Pin Id="KT0aL8uuTyxLx16L0XBKtl" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="VZucdFP1QAbMHvZpPnxlOH" Name="Width" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="UU7uf4taU6sONUGywKMNKY" Bounds="2501,1041" />
+              <ControlPoint Id="CvDupSj5rRVN3mJieo7xQB" Bounds="3090,1219" />
+              <Pad Id="NSxVHoSsU1cLhyjMLzzzmj" Comment="Width" Bounds="2830,1271,35,15" ShowValueBox="true" isIOBox="true" />
+              <ControlPoint Id="QkWLD2hWvG9PIdSYzqiruz" Bounds="2909,1653" />
+              <ControlPoint Id="FX8KPluMrEDPujWYSfvY5I" Bounds="2885,1626" />
+              <ControlPoint Id="EMdQlRZuL5NLn1fsBp07pm" Bounds="3265,1483" />
+              <ControlPoint Id="FsvhIZEQc4lLffGggv20SI" Bounds="3234,1464" />
+              <ControlPoint Id="NjcKqoUjNizOqOYd9gHqN8" Bounds="3327,1208" />
+              <ControlPoint Id="AS21xEOJjDtQSc21RNfl2n" Bounds="3155,1260" />
+              <Node Bounds="3241,1102,113,19" Id="UwdmAgqE8YIOSV9CyVQgTj">
+                <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="ImmutableTexture2D" />
+                </p:NodeReference>
+                <Pin Id="H4GoS8lsX1kN4B9TTM673h" Name="Initial Data" Kind="InputPin" />
+                <Pin Id="N9Vt7wxwXdbOrOFWh7iACu" Name="Size" Kind="InputPin" />
+                <Pin Id="NB8luXZQvzFNWZjJDPt0Pr" Name="Format" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm" />
+                <Pin Id="UuFbLDKBldzQAwm1xAweNj" Name="Recreate On Inital Data Change" Kind="InputPin" />
+                <Pin Id="KFKtkrSRtUKOMFTWml66oT" Name="Recreate" Kind="InputPin" />
+                <Pin Id="U16oIYvMfiEPn0CD6fwzLD" Name="Output" Kind="OutputPin" />
+                <Pin Id="Qont3IhJbPwMPy3ASbN4uP" Name="Has Changed" Kind="OutputPin" />
+              </Node>
+              <Pad Id="SYVCXLVGG8pPusTIhdrO6I" Comment="Size" Bounds="3303,1055,35,28" ShowValueBox="true" isIOBox="true" Value="4, 4">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Int2" />
+                </p:TypeAnnotation>
+              </Pad>
+              <Node Bounds="3237,958,65,19" Id="LWu8MESeehcPdXALMxg8XA">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Cons" />
+                </p:NodeReference>
+                <Pin Id="HxaXDVT5u3wODxFct1TXEL" Name="Input" Kind="InputPin" />
+                <Pin Id="MB2Oh8cLLYeMf71otetAIR" Name="Input 2" Kind="InputPin" />
+                <Pin Id="NcSb6zwS0F2PObGWuAR9tg" Name="Result" Kind="OutputPin" />
+                <Pin Id="Mxnqp2WGi17L07mtPcfaxn" Name="Input 3" Kind="InputPin" />
+                <Pin Id="LkYC8JPAIu5OQcNRYK5Y6h" Name="Input 4" Kind="InputPin" />
+              </Node>
+              <Node Bounds="3257,916,22,19" Id="Nqol9R5c2yALLzIvSpBUhT">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="~" />
+                </p:NodeReference>
+                <Pin Id="NPu58he7shuNQ0G8OlNHNn" Name="Input" Kind="StateInputPin" />
+                <Pin Id="IAhRvhBkLMjLkpgP6a346i" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="3238,1000,65,19" Id="BECokndpQFqM0mP9fyKjk3">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Cons" />
+                </p:NodeReference>
+                <Pin Id="Ds9d8x1uJMALoV7PexrkVn" Name="Input" Kind="InputPin" />
+                <Pin Id="NhVeMlEqaz2PHSp0UPwzwX" Name="Input 2" Kind="InputPin" />
+                <Pin Id="GO3BwopyxIUMtulbsl4jcf" Name="Result" Kind="OutputPin" />
+                <Pin Id="Fohw5R0wtTfMYxawAJ25OX" Name="Input 3" Kind="InputPin" />
+                <Pin Id="Aq7sgrMGnGDPQopIoo5YTr" Name="Input 4" Kind="InputPin" />
+              </Node>
+              <Node Bounds="3238,1041,47,19" Id="PBXXN4746sLLUstVEuZQhJ">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Flatten" />
+                </p:NodeReference>
+                <Pin Id="V1kmJs7Mx7xOOcoFF6TGsb" Name="Input" Kind="StateInputPin" />
+                <Pin Id="B37zOfDIFlmMbi7iadloL6" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <ControlPoint Id="Mggts27At2QL8b8soR7NpH" Bounds="3256,1131" />
+              <Pad Id="PScnJMt7ajoOod1uWfLR9a" SlotId="OejTYBo1NP6N2rml0woFBV" Bounds="3256,1173" />
+              <Node Bounds="3153,1296,96,110" Id="OLRYM2sslU8OF7ps36EeNM">
+                <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
+                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="AvoidNull" />
+                </p:NodeReference>
+                <Pin Id="AvbvC3m1b54MB8NRFWl5PL" Name="Input" Kind="InputPin" />
+                <Pin Id="JWSgNlO37fYMUslHRi5nTM" Name="Output" Kind="OutputPin" />
+                <Patch Id="CWQ4KlVR05FLzC8hjI3cpi" Name="Create Default Value" ManuallySortedPins="true">
+                  <Pin Id="CBbpcFrceZYPBFtQJA9exN" Name="Result" Kind="OutputPin" />
+                  <ControlPoint Id="RUzzhF9iOEwLmQMWayU05w" Bounds="3170,1376" />
+                </Patch>
+              </Node>
+              <Node Bounds="3323,1244,96,110" Id="OmseUEuqLdIMUYgwsp6CSh">
+                <p:NodeReference LastCategoryFullName="Stride.API.Core.Utils" LastDependency="VL.Stride.vl">
+                  <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="AvoidNull" />
+                </p:NodeReference>
+                <Pin Id="I2L29ZEhqiJN3baum1VSih" Name="Input" Kind="InputPin" />
+                <Pin Id="BrjeaDtDHV9P7Ey03uo4hy" Name="Output" Kind="OutputPin" />
+                <Patch Id="U4utc9GxdAbOo72EPKWGWp" Name="Create Default Value" ManuallySortedPins="true">
+                  <Pin Id="QqCwdlWWXXHQTTv5xAzYFV" Name="Result" Kind="OutputPin" />
+                  <ControlPoint Id="Q3zw4mlruaFOKTI3Ka8ncY" Bounds="3340,1324" />
+                </Patch>
+              </Node>
+              <Node Bounds="2564,755,123,19" Id="FijZE5S6Ru1QVxx341dNjZ">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="ShadowCatcherDataRetrieverRenderer" />
+                  <Choice Kind="OperationCallFlag" Name="ShadowCatcherDataKey" />
                 </p:NodeReference>
-                <Pin Id="VvuHJ5p18gULslOclbpmIx" Name="Input" Kind="InputPin" />
-                <Pin Id="KyVTw1RqX3ALxmTZosnBz0" Name="Output" Kind="OutputPin" />
-                <Pin Id="EdNY9C5tIlFN2EvkvaKpM1" Name="Compositor" Kind="InputPin" />
+                <Pin Id="MipkAqIGonrNvIMgf0iJiu" Name="Singleton" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="Mhiump7lQ2KMyc8fto6ghL" Bounds="1922,1161" />
+              <Node Bounds="2488,812,81,26" Id="Gl0bOK3YLwFMYqtruvlxzb">
+                <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll" OverloadStrategy="AllPinsThatAreNotCommon">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
+                  <Choice Kind="OperationCallFlag" Name="TryGetValue" />
+                  <PinReference Kind="InputPin" Name="Property Key">
+                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Stride.Core" LastDependency="Stride.Core.dll">
+                      <Choice Kind="TypeFlag" Name="PropertyKey`1" />
+                      <p:TypeArguments>
+                        <TypeParameterReference />
+                      </p:TypeArguments>
+                    </p:DataTypeReference>
+                  </PinReference>
+                  <PinReference Kind="OutputPin" Name="Value" ParameterModifier="ref">
+                    <p:DataTypeReference p:Type="TypeParameterReference" />
+                  </PinReference>
+                </p:NodeReference>
+                <Pin Id="BkeAlfR77sbLpd0TvME5yf" Name="Input" Kind="StateInputPin" />
+                <Pin Id="GR6CUyUiLuILllqWMILdB9" Name="Property Key" Kind="InputPin" />
+                <Pin Id="Nkt8caJukLtOY7QTcLihbI" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="FAnM4sFo90lPRp8nnfswBW" Name="Result" Kind="OutputPin" />
+                <Pin Id="JZc56BxxbKGOYVU8WV5OYu" Name="Value" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2419,768,74,26" Id="T5O5gk6DfRoQL729Iug6Kg">
+                <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Tags" />
+                </p:NodeReference>
+                <Pin Id="VCWrqpzf2aTMUP62d7jKIX" Name="Input" Kind="StateInputPin" />
+                <Pin Id="F3VjN1hR4whP3Bhocp8XAs" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="AJkGDEsMrINMDUNNktOFUT" Name="Tags" Kind="OutputPin" />
+              </Node>
             </Canvas>
-            <Patch Id="ErKdFlYsLL3LcRT3hAojhq" Name="Create" />
-            <!--
-
-    ************************  ************************
-
--->
-            <ProcessDefinition Id="HEQMCiBtPVQN8E2zjQVxJQ" IsHidden="true">
+            <Patch Id="ErKdFlYsLL3LcRT3hAojhq" Name="Create" ParticipatingElements="I5TXlz8LnciPhtQvsD9Jn7" />
+            <ProcessDefinition Id="HEQMCiBtPVQN8E2zjQVxJQ" HasStateOut="true">
               <Fragment Id="E3HWjWwixOvNhAbDWqe5bc" Patch="ErKdFlYsLL3LcRT3hAojhq" Enabled="true" />
               <Fragment Id="H1Ms8wFsY5uNLvTk3UkyOd" Patch="Jqk0aKHvQsjQJS2JGTHBEe" />
               <Fragment Id="LV3bwxoZvanLyBjni9vOWo" Patch="KC6ZqrN2eEUPAVDVcZmkMW" Enabled="true" />
-              <Fragment Id="JRQxFXVK1S3Lop1frru2hV" Patch="CvcVK2UQo4YNiSlVGvjgTI" />
-              <Fragment Id="RzQWYRNkFTHL88HbWNTgWj" Patch="FnmgjOKJhWRMpYSMAlFN6q" />
+              <Fragment Id="JRQxFXVK1S3Lop1frru2hV" Patch="CvcVK2UQo4YNiSlVGvjgTI" Enabled="true" />
+              <Fragment Id="RzQWYRNkFTHL88HbWNTgWj" Patch="FnmgjOKJhWRMpYSMAlFN6q" Enabled="true" />
             </ProcessDefinition>
-            <Patch Id="Jqk0aKHvQsjQJS2JGTHBEe" Name="Draw" ParticipatingElements="OnzPbiWgADvOpmeUJ0iwIk,Vuq7FQKMqr2NIYjzTeJ7kR,RTQOzG3u3zOP3iufTDceOG,OkRdYOAhN7TOIQCtO8KxE2,HWdOVVwN8ZWP6DqIBHj1OV">
+            <Patch Id="Jqk0aKHvQsjQJS2JGTHBEe" Name="Draw" ParticipatingElements="Gbpn46BlnOaNcnX3PFhkVI,VmWFYGfdt47M5KDXes0YMO,Q7FRlS5L0DCL7rwcX4txGh">
               <Pin Id="H5CWmZ9XDPaLek5JhguQ2f" MergeId="45458" Name="Context" Kind="InputPin" />
             </Patch>
             <Link Id="PAdZQhTXVprNvbDTEUttYc" Ids="H5CWmZ9XDPaLek5JhguQ2f,JmyUN95v58lQDkwdKK7ZxQ" IsHidden="true" />
@@ -2920,9 +2774,11 @@
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pin>
-              <Pin Id="GcUuVnKqTiWMr16N6YNCZZ" MergeId="1340" Name="Shadow Color" Kind="InputPin" Bounds="917,528" />
               <Pin Id="UuLDUc3sIMoLbVe9BfV48G" MergeId="1368" Name="Normal Offset" Kind="InputPin" Bounds="1002,557" Visibility="Optional" />
-              <Pin Id="SMq7r9CyGtXLfPKVO9mvcs" Name="Compositor" Kind="InputPin" />
+              <Pin Id="UmXfHztstA9P5huh8IJs7s" Name="Shadow Texture" Kind="InputPin" Bounds="993,603" Visibility="Optional" />
+              <Pin Id="TdwbR8OQdZiQCvpKoNXZsn" Name="Shadow Tint" Kind="InputPin" Bounds="917,528" />
+              <Pin Id="O8aBDagyarIMSdQyLL6NSY" Name="Other Texture" Kind="InputPin" Bounds="1021,624" Visibility="Optional" />
+              <Pin Id="QYO9BDAYyQEMkgYsg2Nu26" Name="Other Tint" Kind="InputPin" Bounds="1052,592" Visibility="Optional" />
             </Patch>
             <Patch Id="CvcVK2UQo4YNiSlVGvjgTI" Name="SetDepthStencilState">
               <Pin Id="OUBgRBGTroCP2CqMmjxpq1" MergeId="1384" Name="Depth Stencil State" Kind="InputPin" Visibility="Optional" />
@@ -2930,52 +2786,78 @@
             <Patch Id="FnmgjOKJhWRMpYSMAlFN6q" Name="SetRasterizerState">
               <Pin Id="OB1VEuJaHTRQR5UWJd9DKc" MergeId="1387" Name="Rasterizer State" Kind="InputPin" Visibility="Optional" />
             </Patch>
-            <Link Id="CQtOASSwbSdNTjKefzJNBH" Ids="QWaF7FGYuNpL5g5oIvn1lD,HNJidM6gci3NKD1G9rB5vy" />
-            <Link Id="Vuq7FQKMqr2NIYjzTeJ7kR" Ids="QWaF7FGYuNpL5g5oIvn1lD,NvF8gz0v0IYLDQ7gkqwtIM" />
-            <Link Id="RTQOzG3u3zOP3iufTDceOG" Ids="NHR2FXylqiTN8BvDCvrKcQ,FenyPqc0zkhQQIHwsmTJWp" />
-            <Link Id="P20HPHeBafpMVNUOGQoXNr" Ids="S3Bwc27bLxgPYEOP1Q7Ljv,Pmkk6PyrSbTNH1gW8CJpo1" />
-            <Link Id="GDt5uQvSpBJMBaSTCpu4uI" Ids="ESh5XkMzKl7M6Eq35hGpb6,M1eEJ77dUeNLO60zHhtL54" />
-            <Link Id="IyL8A97CSYxPHAZiDsZhxT" Ids="HSMu4yNkdvJM58B7eGAjbg,JOd7Yv1YpGELNrmDCV4gkO" />
-            <Link Id="FamRLHYs7svMoYJK4mcXCy" Ids="UPRhXxkWLm2LnaT2ThYJ7T,B6WSt3TnXvuO2BChyS63KG" />
-            <Link Id="F5ZFEbsPQ4PP6ZSXSBRY9b" Ids="GNgJFHqWapoQPIVfRJVXKG,JbsV0gC5MRfPbuZHQlGdma" />
-            <Link Id="Ao970gB8cVTLsypDG93r3v" Ids="KXnN18wv9OjPIqttmqtrtx,GNgJFHqWapoQPIVfRJVXKG" IsHidden="true" />
-            <Link Id="HGlMdgCsoG2PpUOKC2C8VA" Ids="GcUuVnKqTiWMr16N6YNCZZ,P33MTf6WnozOM7eGhYzilR" IsHidden="true" />
-            <Link Id="So6KnJ30emxMecdcydTzH5" Ids="Cd6rUUbI8krNp4BatW8pcH,KnJ7LEIBAhZNYQIrH10z9G" IsHidden="true" />
-            <Link Id="GSYhtZHxEwPMcdQUF67dk3" Ids="P33MTf6WnozOM7eGhYzilR,Jn4MQIq2375PYWwPp3dQCK" />
-            <Link Id="Ry5YW8vdZghNsAUjFh2hAQ" Ids="KnJ7LEIBAhZNYQIrH10z9G,Lebv8mH06wrLu5c14Xg9E8" />
-            <Link Id="OkRdYOAhN7TOIQCtO8KxE2" Ids="FydGgPzgtFQMI8PHwIModE,UqLSa6HalcQL1GQmP9UoAo" />
-            <Link Id="JpsJvkVF5apNHa8XtbPHXB" Ids="ELmLkHRLBD2PdkDWkgt8PD,DNSzEhF4osKLfQWAcHXRsp" IsHidden="true" />
-            <Link Id="ENlc8aORWgXOhrS1EXFPM3" Ids="K9myjgkNuMINrrZf5U7PWd,KHWIEvYfRBfQCDhdvjZsy1,BWHwNwXZv8XLuou0kSbaNq" />
-            <Link Id="LYuWPdsTAxdLWyhnnJgzDN" Ids="GWfO7Gwma58MbJ7GvPQlMw,ELmLkHRLBD2PdkDWkgt8PD" />
-            <Link Id="IIjjroxkOcdLnzsft5fSjt" Ids="AeiWyUQBxrhMEeWH0OiD3Z,VcGjpTTBObDOKYcGzyybau" />
-            <Link Id="LeUTEwp6YjtLLKD92d91no" Ids="C1dvIEE1BPNLNdYb9LLfXV,C46kWyP2J4ZPjmm981rMAj" />
-            <Link Id="BvKyQbbxqgbPN39nlnrNLb" Ids="DDq9NtmWIibMZimyUepMV5,UHghVFLFfyCLGyz7aWCD1O" />
-            <Link Id="RF8tsw8ySmfLAMbmTsiCUo" Ids="VYRAoytJKcLL0HJXs4Qiza,MIXSTF2wBmTLXbIKJ05UbT" />
-            <Link Id="LIpgjtjW9wZPdUo77a8Ynd" Ids="EyJOvglCgX4MLBxyCiudK5,MxnYiw6f9JDLwlj10swonE" />
-            <Link Id="K0AMGsNDHm8LdhrcO4jn65" Ids="N4ba85Pr9LyOBHampi4L7u,MnIrnhAhFEhLfmc9iOtcyz" />
-            <Link Id="REIcZSuHSebMFCTIf1uFm3" Ids="IvG0KdoQ9rGMCfgUN0lZZp,JgC6MYbxlS1QDdHNbi7qnI" />
-            <Link Id="Rd9hbd9HvNtQBNFIgyt0sQ" Ids="K76lTijzjZZQRXcbGnQyMk,LjRcLyRYjQTL6r2G72U1Dx" />
-            <Link Id="Oz2YwVmvkzUNY3MjFfw242" Ids="KgclaBeMwdbPWj3NF7TSN5,ML895Ub6iwHMn6bY2qWHrC" />
-            <Link Id="V6YUEjFYKo7NFvq0V3l7pK" Ids="QnqWTcFPzeaOlIWK6DFZNV,I1KCXRFlc56LhwEiPPZp2E" IsHidden="true" />
-            <Link Id="TQrGvM8OtEQOsLX6m9SIfQ" Ids="MbevPEfTVHiQEJmaQRQzTc,F8JhmocSEZBQPpciz0Gnvp" />
-            <Link Id="CGbS0avndBbLPYXWpHEF20" Ids="TylSnZ7ElCDNiTNQROZc85,IJkUUH6AV6oNyYyM3wfyLG" />
-            <Link Id="Ds2mkLdB75lMDTFIyUfqm0" Ids="UdxrbsIVK34O08hANLhXh7,VHFY2zPYpWCNheQDczgdTm" />
-            <Link Id="GmwFkevZXUmLesj6C7u7EK" Ids="CNnpVviRFLVPLLghhCEE7I,MSgrm4PPCcGPrkethMgFSR" />
-            <Link Id="PmShnVcdAHYNfkAPOpuuDb" Ids="KoGLpmJGmNuMBVCYJqJuOj,QsDNnDvS7AVQZBcL37Pe5y" />
-            <Link Id="QP9gl4Aa4YsOFCl520WFzE" Ids="QsDNnDvS7AVQZBcL37Pe5y,BjiBk8NXp8HL2hj8ydkah3" />
-            <Link Id="KT9kc3I6Y2JNny8N7zfXOE" Ids="QsDNnDvS7AVQZBcL37Pe5y,HkwusbOBxEPPHsUPLlB6W4" />
-            <Link Id="HftbbrL1E7HNwCKph6kxy1" Ids="TUahzGGrtU2MVOcrUXDgvJ,VbZkiWB0WXvQDRKRAx2DcX" />
-            <Link Id="KiHT7tSyrm3NEXtBnYS3gi" Ids="OUBgRBGTroCP2CqMmjxpq1,TUahzGGrtU2MVOcrUXDgvJ" IsHidden="true" />
-            <Link Id="RcLu9GVIMGPNd1kvxiTKtb" Ids="NKbckpPLKfhONKlyJh6FV1,VZqR9o8TNZgPCS6vWCNmVt" />
-            <Link Id="ROtefQBDUh8NSNuU5X7MlC" Ids="OB1VEuJaHTRQR5UWJd9DKc,NKbckpPLKfhONKlyJh6FV1" IsHidden="true" />
-            <Link Id="TCMKqxBQKE9NWxck9rqL1P" Ids="I1KCXRFlc56LhwEiPPZp2E,IeIhDGc3Q7zQFT4up5opPS" />
-            <Link Id="BmEv7JsnPzEMl7EFnblFOp" Ids="Hm26lRA6GDkPzesjqTsn95,Qyj9y0GuanDMZvhmuxv0qE" />
-            <Link Id="VtAHkfFkFBlLIPybaePTlD" Ids="UuLDUc3sIMoLbVe9BfV48G,Hm26lRA6GDkPzesjqTsn95" IsHidden="true" />
             <Link Id="D1x4G40Y4SGO3m7Rbhjv6C" Ids="JmyUN95v58lQDkwdKK7ZxQ,NEO6q6I2i4dPjNnJzhLmGp" />
-            <Link Id="HWdOVVwN8ZWP6DqIBHj1OV" Ids="A4HO3ad8iuwOGSNse4CpzN,VvuHJ5p18gULslOclbpmIx" />
-            <Link Id="AyL6FEN09egLiYbnZmTZmH" Ids="KyVTw1RqX3ALxmTZosnBz0,QlK5slwNHftPF4bdWHCAQV" />
-            <Link Id="QmndetAKJ19MRdkrcj6K9h" Ids="Mhiump7lQ2KMyc8fto6ghL,EdNY9C5tIlFN2EvkvaKpM1" />
-            <Link Id="SEyMCNKYWI5MlIZcuZIWhh" Ids="SMq7r9CyGtXLfPKVO9mvcs,Mhiump7lQ2KMyc8fto6ghL" IsHidden="true" />
+            <Slot Id="OejTYBo1NP6N2rml0woFBV" Name="Default" />
+            <Link Id="CAe434zbBVaMc3lOgMkiDe" Ids="EqoiojoXGwtMqwnWThJ1JN,Dd3A51t1YAYNi9sJ1eylgM" />
+            <Link Id="Gbpn46BlnOaNcnX3PFhkVI" Ids="EqoiojoXGwtMqwnWThJ1JN,S0dVjZq3snlPxk4WCyhmzl" />
+            <Link Id="VmWFYGfdt47M5KDXes0YMO" Ids="R0NYQHJ7xblOD4BN0a7y5I,ShdwcUqACAdQQGPvf1HMcs" />
+            <Link Id="JVfiwQaOVoMNzlhEbPgxqE" Ids="AeMqXBxV37WLXypr1WqLEW,KpRd5z5MFKzMaUap3cMeLk" />
+            <Link Id="CGfnjB4MaGvQNuByKKc2IP" Ids="QjvxBhfZhxfOXb4XWTIf6O,Ob9iAtsFyrbN3pxCRcZ518" />
+            <Link Id="V8Ky3t0VO7UOSV30QgaFlJ" Ids="FScF16eAHHfMnFBeyjZ9Pu,LZzE02ChVO5OsRZfmPpMpZ" />
+            <Link Id="FaIOqfxYrn7PUHT8zMgkGT" Ids="BZJwQj3XBxQLXPiaZvCthJ,KtzzL5PmE7LMvqBfsV5aq7" />
+            <Link Id="AFIRRGrk1QIPMWhxUWf2Du" Ids="LbsvtNcaHprLWUhzfQ7IlQ,JuXCGJQrqOvNfhcHItbTkc" />
+            <Link Id="Uz4YTFwz2QILxt0rxiL5LY" Ids="KXnN18wv9OjPIqttmqtrtx,LbsvtNcaHprLWUhzfQ7IlQ" IsHidden="true" />
+            <Link Id="JPr8gV7EIyUNWb7VIeu0bN" Ids="TdwbR8OQdZiQCvpKoNXZsn,C2oIF41pTsPPxMvbTp9WMo" IsHidden="true" />
+            <Link Id="LisxfHFT2qnLakXyP9lM4r" Ids="Cd6rUUbI8krNp4BatW8pcH,AqthvFRkKa9OjYTX3NJyYF" IsHidden="true" />
+            <Link Id="FqFvgDUB0VNLLCpzINnxTL" Ids="AqthvFRkKa9OjYTX3NJyYF,UjhuQ6fwBhPN9CdC8Zm6la" />
+            <Link Id="Q7FRlS5L0DCL7rwcX4txGh" Ids="T2GnL1RO1RbMbGev2XXN4c,UoSotBsaBNTOPXUOceWYFT" />
+            <Link Id="NLfL1qakf5DQJzVS4moUYp" Ids="GG50zhylpZCOkQvEW5IPLV,H6ILxGVKFqBP2UwRS5D9WL" IsHidden="true" />
+            <Link Id="RWrWWsaU83GQHwtkzYpGuW" Ids="R3vzXKHfAkVMu9X0GS4gVv,UU7uf4taU6sONUGywKMNKY,NwDv66IwoglPgRkEEaQn2C" />
+            <Link Id="SZrqxxrcYtONVuOIeRZiuq" Ids="VCVW5DD47hQNld7JXsn36b,GG50zhylpZCOkQvEW5IPLV" />
+            <Link Id="BTjDFFFrlTFM80YoCB9KYJ" Ids="DQBQB7CF2TBQAZmDuWDeTY,HQXEtZnFhuwL3OmkCSp3pQ" />
+            <Link Id="DzAnVFf8sOLMjOwlSWNvFK" Ids="P18svlScjFmOv0PFSwDCNh,AxNOiJ2PZfSN25Cmu6AMYI" />
+            <Link Id="AO3ZJZuc5sYNDoYWnu6zIV" Ids="LISx9LVm39jLkRQqQD85Wl,E5KCG7xKwLBOi3bIMm75XO" />
+            <Link Id="S5meVnowiWGPvk4vEYwhPQ" Ids="B7FhjROgOEXQEpXF6pUKo7,K1AVfqFVKauMyrg2PneWM2" />
+            <Link Id="NGooHmgLK71OtZVev48MW4" Ids="BPNLoqDTpPsPxulnDLFLfY,UDZGx9TaENTNv1DpVezrMZ" />
+            <Link Id="DhEhUFDrMicL6QlACUz8Wu" Ids="JMHJTMZaDkGMZFeljeNqfS,Opu7B03FJbQOEkZr75gjET" />
+            <Link Id="BayXt3vwSPIMpstiYLio0W" Ids="IxtKMr32FHmMmxkUZh5Iam,KOVQSxtgJQYL1VqC6M1Vga" />
+            <Link Id="UhENzuRHe7nPvXCz7LeBUc" Ids="KT0aL8uuTyxLx16L0XBKtl,FgJiTl3z8eWPB8BG5jhhxN" />
+            <Link Id="MeewmvXYW0BQAXlZj4creJ" Ids="KyIBi6STqN2MGVvAHO2is1,Kipu41TxSpIN8eE4AxlN68" />
+            <Link Id="K3xButpfgonOgKYYQmBNTj" Ids="QnqWTcFPzeaOlIWK6DFZNV,CvDupSj5rRVN3mJieo7xQB" IsHidden="true" />
+            <Link Id="ATtMqceuzIWLkm2sSsXwwW" Ids="BY8Hwzo7aQ2NhLcS1i7k0I,MIOZzirlycsNKPbUh7oIlb" />
+            <Link Id="LISUeBNAC6APFPFcY0XUOs" Ids="DLSFuazRCotMYNAjTKQ597,NkhB6AocjEhNdcxCKmnnsZ" />
+            <Link Id="OeBjwveUnX6LbCv69ukHoB" Ids="P9AqbHgdvXDNbeIfWDcpvw,BJhxpQDa3umL5ToaQ4UhAh" />
+            <Link Id="RsVrwzCfU0fNjsTdqmgwOY" Ids="QamoN9H9dfpPUZdep5WoYS,B1PRP7OylfCN1cnxIHrSkD" />
+            <Link Id="D4k00TtTKeFQX6WhVsZKLt" Ids="VZucdFP1QAbMHvZpPnxlOH,NSxVHoSsU1cLhyjMLzzzmj" />
+            <Link Id="NZb5QbgsGm6Mz5P2H6MVdI" Ids="NSxVHoSsU1cLhyjMLzzzmj,EAokkHryU4oLWA9DiRv0Hc" />
+            <Link Id="OUwxPeL8DgkNEEzU3DC5tr" Ids="NSxVHoSsU1cLhyjMLzzzmj,TWHULF1KKMTMY03ZRxLN2w" />
+            <Link Id="TxjJ3MagKTsLEem8oF9iaK" Ids="OUBgRBGTroCP2CqMmjxpq1,QkWLD2hWvG9PIdSYzqiruz" IsHidden="true" />
+            <Link Id="MUY5aHFWj1gMKZfj7DnPrI" Ids="FX8KPluMrEDPujWYSfvY5I,SDJHTZJYrCvLtBVu3fXHFd" />
+            <Link Id="NSLfuRsgNBxMrTGpRl7iEA" Ids="OB1VEuJaHTRQR5UWJd9DKc,FX8KPluMrEDPujWYSfvY5I" IsHidden="true" />
+            <Link Id="R6qJ5TmZl0mM9nesVjMqWc" Ids="CvDupSj5rRVN3mJieo7xQB,MhZIlBa4dDcNL4IByhD4Ii" />
+            <Link Id="JCku6pqmXQ0QC6J1PnxskA" Ids="EMdQlRZuL5NLn1fsBp07pm,GSzpOV0miiPOFdjcN0B7kE" />
+            <Link Id="U8ITCfbvs6wOZV3cNlBjgB" Ids="UuLDUc3sIMoLbVe9BfV48G,EMdQlRZuL5NLn1fsBp07pm" IsHidden="true" />
+            <Link Id="L7dClIBn57JLlx5bDQ4zGf" Ids="QkWLD2hWvG9PIdSYzqiruz,JqddSxONwVcMv9ykHwsddR" />
+            <Link Id="MrVtU9yA63QM1vIgzm1Tpd" Ids="C2oIF41pTsPPxMvbTp9WMo,H4NDBUUF7YwLfkHgjf0ybT" />
+            <Link Id="RltSyVcWtwAL9qoYLO25GI" Ids="FsvhIZEQc4lLffGggv20SI,OWHkNVKaYONN7rwAxjDiyA" />
+            <Link Id="UCpy9Hq0LLOLBLISFJiYNc" Ids="QYO9BDAYyQEMkgYsg2Nu26,FsvhIZEQc4lLffGggv20SI" IsHidden="true" />
+            <Link Id="B2WfqzRPlKRMEP0xBeNNZS" Ids="O8aBDagyarIMSdQyLL6NSY,NjcKqoUjNizOqOYd9gHqN8" IsHidden="true" />
+            <Link Id="UPVuPpGZJYiQGOAU8Zu0wB" Ids="UmXfHztstA9P5huh8IJs7s,AS21xEOJjDtQSc21RNfl2n" IsHidden="true" />
+            <Link Id="OCRehOgrM9mLIdvpOPep52" Ids="SYVCXLVGG8pPusTIhdrO6I,N9Vt7wxwXdbOrOFWh7iACu" />
+            <Link Id="KAuFedGybwJM4dotluohFo" Ids="IAhRvhBkLMjLkpgP6a346i,HxaXDVT5u3wODxFct1TXEL" />
+            <Link Id="CHEsI3M8on7MCpJZ4Nmq1x" Ids="IAhRvhBkLMjLkpgP6a346i,MB2Oh8cLLYeMf71otetAIR" />
+            <Link Id="G0U5Q59qatbLTFli4gNlkl" Ids="IAhRvhBkLMjLkpgP6a346i,Mxnqp2WGi17L07mtPcfaxn" />
+            <Link Id="KVODwbIM5Q8MFtfg6rNSaZ" Ids="IAhRvhBkLMjLkpgP6a346i,LkYC8JPAIu5OQcNRYK5Y6h" />
+            <Link Id="E3lQlLSHVp3PDkXg9lQDTe" Ids="NcSb6zwS0F2PObGWuAR9tg,Ds9d8x1uJMALoV7PexrkVn" />
+            <Link Id="UbNjrXCZGOROg8eIlFDzmO" Ids="NcSb6zwS0F2PObGWuAR9tg,NhVeMlEqaz2PHSp0UPwzwX" />
+            <Link Id="BW3bmlfXQrEMpqWOQo9oaR" Ids="NcSb6zwS0F2PObGWuAR9tg,Fohw5R0wtTfMYxawAJ25OX" />
+            <Link Id="HyH0jhZvY2gOmwychIi50S" Ids="NcSb6zwS0F2PObGWuAR9tg,Aq7sgrMGnGDPQopIoo5YTr" />
+            <Link Id="EqFThA0zU4FPl7zor4Z3sR" Ids="GO3BwopyxIUMtulbsl4jcf,V1kmJs7Mx7xOOcoFF6TGsb" />
+            <Link Id="EK5Lbd8YXytNNFJeD5LC1i" Ids="B37zOfDIFlmMbi7iadloL6,H4GoS8lsX1kN4B9TTM673h" />
+            <Link Id="I5TXlz8LnciPhtQvsD9Jn7" Ids="U16oIYvMfiEPn0CD6fwzLD,Mggts27At2QL8b8soR7NpH,PScnJMt7ajoOod1uWfLR9a" />
+            <Link Id="FvT2kMxPbLbMUOMqCS8q8M" Ids="RUzzhF9iOEwLmQMWayU05w,CBbpcFrceZYPBFtQJA9exN" IsHidden="true" />
+            <Link Id="TDZxVlVA0lZQJnukJmRLeQ" Ids="AS21xEOJjDtQSc21RNfl2n,AvbvC3m1b54MB8NRFWl5PL" />
+            <Link Id="OQ8hs1zueyWOCMKN1rzo1j" Ids="PScnJMt7ajoOod1uWfLR9a,RUzzhF9iOEwLmQMWayU05w" />
+            <Link Id="FufVJcvyRFnM7ESsJNv1UT" Ids="JWSgNlO37fYMUslHRi5nTM,AhXS6nuqsF0M5M3JwKm1ux" />
+            <Link Id="OLwGET9FX8eONmPprxYdRQ" Ids="Q3zw4mlruaFOKTI3Ka8ncY,QqCwdlWWXXHQTTv5xAzYFV" IsHidden="true" />
+            <Link Id="E0c5KM54fOWPR7zkOMJLTG" Ids="NjcKqoUjNizOqOYd9gHqN8,I2L29ZEhqiJN3baum1VSih" />
+            <Link Id="GEVyQIPBK2hN7GEDRzwKQw" Ids="PScnJMt7ajoOod1uWfLR9a,Q3zw4mlruaFOKTI3Ka8ncY" />
+            <Link Id="Mm0r2CtFvEoNNzcByMFnEF" Ids="BrjeaDtDHV9P7Ey03uo4hy,P1AvbWgZSRnM8TPnKzhrc9" />
+            <Link Id="TUSyxiqleJvP64UA4eijqY" Ids="CT97BEWDhmBPGcVX9NAhPe,QlK5slwNHftPF4bdWHCAQV" />
+            <Link Id="BSsWY5IVZuLOHvz12JTjd8" Ids="MipkAqIGonrNvIMgf0iJiu,GR6CUyUiLuILllqWMILdB9" />
+            <Link Id="SsSEmS7i3zxMhOkGNfdiNP" Ids="JZc56BxxbKGOYVU8WV5OYu,KoJxHMTLb2rMPviivjrifo" />
+            <Link Id="B0xL33M7z2lQZUGs5hvUmL" Ids="JmyUN95v58lQDkwdKK7ZxQ,VCWrqpzf2aTMUP62d7jKIX" />
+            <Link Id="MLX5ALuFXhYPWq8nBH9EhI" Ids="AJkGDEsMrINMDUNNktOFUT,BkeAlfR77sbLpd0TvME5yf" />
           </Patch>
         </Node>
         <!--
@@ -2983,7 +2865,7 @@
     ************************ ShadowCatcherDataRetrieverRenderer ************************
 
 -->
-        <Node Name="ShadowCatcherDataRetrieverRenderer" Bounds="518,749" Id="KRKJA7TMNEpL7U1Dv4xB32">
+        <Node Name="ShadowCatcherDataRetrieverRenderer" Bounds="523,715" Id="KRKJA7TMNEpL7U1Dv4xB32">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="ClassDefinition" Name="Class" />
           </p:NodeReference>
@@ -2994,8 +2876,8 @@
           </p:Interfaces>
           <Patch Id="UnCOxsvliVaPrGoE68On4m">
             <Canvas Id="L04ZWGHfmQaMGNmzB9nXat" CanvasType="Group">
-              <ControlPoint Id="C8x51fcLrN1OS8lL4g9LJ5" Bounds="822,743" />
-              <Node Bounds="1361,1099,51,26" Id="MQdGP5bxJN2Njr0LO7pv0O">
+              <ControlPoint Id="C8x51fcLrN1OS8lL4g9LJ5" Bounds="1330,522" />
+              <Node Bounds="1410,1649,51,26" Id="MQdGP5bxJN2Njr0LO7pv0O">
                 <p:NodeReference LastCategoryFullName="Stride.API.Rendering.IRenderer" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="MutableInterfaceType" Name="IRenderer" />
@@ -3004,20 +2886,23 @@
                 <Pin Id="NpZSrwEZN5GOvO5HU8assO" Name="Input" Kind="StateInputPin" />
                 <Pin Id="DAT8KgXFqP5LykZU3v5buT" Name="Context" Kind="InputPin" />
                 <Pin Id="IQFWcGSbr2DLZsm8vfgya4" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="Ol8KVnkNK1WNgmwY1YZPWH" Name="Apply" Kind="InputPin" DefaultValue="False" />
               </Node>
-              <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="1364,909" />
-              <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="1363,853" />
-              <Node Bounds="884,1191,366,114" Id="E2oflgh7P6CM3IqV2TYFc9">
+              <Pad Id="Nx6K7kWkA87OtTB6bRmS1k" Bounds="1412,1573" />
+              <ControlPoint Id="K5oNmlJ0fOSMp4V5bX6uiJ" Bounds="1412,1538" />
+              <Node Bounds="938,1268,413,324" Id="E2oflgh7P6CM3IqV2TYFc9">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 </p:NodeReference>
                 <Pin Id="KxBUKEtfv0fOxAQDvjnjxZ" Name="Condition" Kind="InputPin" />
+                <ControlPoint Id="TZQ2Hot5LNzPNBSybYBMtt" Bounds="1334,1274" Alignment="Top" />
+                <ControlPoint Id="JvUSaK0Yr5UNeZ5crtundU" Bounds="1332,1586" Alignment="Bottom" />
                 <Patch Id="NVm0f2JOHhOMbyHJUlAFrx" ManuallySortedPins="true">
                   <Patch Id="BqhqQQMgSiBQAz4lJmAZud" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="L1y86PLt1KkMUcqinp6zKl" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="896,1259,81,26" Id="AcWwmmky3c7MBjc6PXWyWd">
+                  <Node Bounds="950,1448,85,26" Id="AcWwmmky3c7MBjc6PXWyWd">
                     <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="Stride" />
@@ -3025,11 +2910,11 @@
                       <Choice Kind="OperationCallFlag" Name="Set" />
                     </p:NodeReference>
                     <Pin Id="EPlb5vrWJZ8P5VtmajBQ27" Name="Input" Kind="StateInputPin" />
-                    <Pin Id="FZp5qnymERONLavHVZuT7J" Name="Property Key" Kind="InputPin" />
-                    <Pin Id="RATmuWYtZAEMPrtiEcPF30" Name="Tag Value" Kind="InputPin" />
+                    <Pin Id="Vn9uP1EG9lzQIpZ950Kfzy" Name="Property Key" Kind="InputPin" />
+                    <Pin Id="NIljp4eBBPNP2GU9WODEJ1" Name="Tag Value" Kind="InputPin" />
                     <Pin Id="QnYylTDVqZvL20CCf6OwqT" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="1121,1214,117,19" Id="G6uykTFllYeNhgISZJviWo">
+                  <Node Bounds="1030,1346,117,19" Id="G6uykTFllYeNhgISZJviWo">
                     <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="GetShadowParameters" />
@@ -3037,9 +2922,29 @@
                     <Pin Id="Ncu9UhXBddDQJbNOYVnmcN" Name="Input" Kind="InputPin" />
                     <Pin Id="K3fuXPky3owOXIsRIqyPol" Name="Output" Kind="OutputPin" />
                   </Node>
+                  <Node Bounds="950,1515,74,26" Id="L9WJwzXE2xjLWUS36NEgVe">
+                    <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="SetTags" />
+                    </p:NodeReference>
+                    <Pin Id="MAjVz8F1ql9QDHa5ZxitCk" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="BXzovYZWWJbQX9U0z42z9v" Name="Value" Kind="InputPin" />
+                    <Pin Id="IDAPygsxibALZnZ2ygil3Y" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="1030,1390,94,26" Id="RAnNXOh8oUbPe3MOQO3c3C">
+                    <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SetFrameNumber" />
+                    </p:NodeReference>
+                    <Pin Id="TC03cat8lzlM4YFcqgsVdJ" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="M00kkHOXfOeLZnk4sJZKDQ" Name="Frame Number" Kind="InputPin" />
+                    <Pin Id="QBMTr7t38mwQb0zIwpiTUc" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <ControlPoint Id="MwgFzhiXztSLQqBcYbesIA" Bounds="1248,1453" />
                 </Patch>
               </Node>
-              <Node Bounds="823,899,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
+              <Node Bounds="887,675,74,26" Id="UyQro5w7LrkLPA9IdW6KtW">
                 <p:NodeReference LastCategoryFullName="Stride.Core.ComponentBase" LastDependency="Stride.Core.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="ComponentBase" NeedsToBeDirectParent="true" />
@@ -3049,7 +2954,7 @@
                 <Pin Id="DMbYsqvPc4SPThtdslUlUE" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="EDRuTOkzYh6PRNnmbXMt0l" Name="Tags" Kind="OutputPin" />
               </Node>
-              <Node Bounds="895,982,81,26" Id="ITJnvf0PA2MOU3PyFQtZqJ">
+              <Node Bounds="956,732,174,26" Id="ITJnvf0PA2MOU3PyFQtZqJ">
                 <p:NodeReference LastCategoryFullName="Stride.Core.PropertyContainer" LastDependency="Stride.Core.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="PropertyContainer" />
@@ -3072,23 +2977,135 @@
                 <Pin Id="C1JV9EANnLvLpeklUutEFA" Name="Result" Kind="OutputPin" />
                 <Pin Id="AKyDxhhOVjzMMKRZv0Shny" Name="Value" Kind="OutputPin" />
               </Node>
-              <Node Bounds="932,1037,37,19" Id="J7snb5PbMDnLSr0Yv8FN3G">
-                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="NOT" />
-                </p:NodeReference>
-                <Pin Id="EtYP5E8bjrwPgefOxIONir" Name="Input" Kind="StateInputPin" />
-                <Pin Id="EWoOSpfJn8WLVInjrwqZe7" Name="Output" Kind="StateOutputPin" />
-              </Node>
-              <Pad Id="S78rsCgoGA1LtdGfKVYSJJ" SlotId="TCuBmbFlbQ6PEmI1LLzLY6" Bounds="1602,898" />
-              <ControlPoint Id="PERgaE6IPCxNcvWx4SVk8R" Bounds="1602,849" />
-              <Node Bounds="1058,947,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
+              <Pad Id="S78rsCgoGA1LtdGfKVYSJJ" SlotId="TCuBmbFlbQ6PEmI1LLzLY6" Bounds="1124,1217" />
+              <ControlPoint Id="PERgaE6IPCxNcvWx4SVk8R" Bounds="1124,1168" />
+              <Node Bounds="993,675,123,19" Id="MYcOCyaPrZjO97H6UxXJhl">
                 <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ShadowCatcherDataKey" />
                 </p:NodeReference>
                 <Pin Id="FqV2QIIT2vsLlmwb3dzckZ" Name="Singleton" Kind="OutputPin" />
               </Node>
+              <Node Bounds="1456,1612,65,19" Id="OyTLWhaP0zWPO09w9jlcMh">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                </p:NodeReference>
+                <Pin Id="OiLBoODHrowOqNBXuizUrE" Name="X" Kind="InputPin" />
+                <Pin Id="DvMM4qFNpUqNRz2r999upe" Name="Result" Kind="OutputPin" />
+                <Pin Id="OByLMaS018zQI5VSwk04uG" Name="Not Assigned" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="1066,835,365,218" Id="HY2STWLe5juNTYmvvb86Zh">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="FekHGHekK2kPBqxiCawpnl" Name="Condition" Kind="InputPin" />
+                <ControlPoint Id="Ms1o8mpEhAYPHEw1Jb9xsF" Bounds="1333,841" Alignment="Top" />
+                <ControlPoint Id="IxqQrHJ91xJQcaGAqAQAz6" Bounds="1333,1047" Alignment="Bottom" />
+                <ControlPoint Id="RaIamlQu0lVLjqhiC6KrW7" Bounds="1126,1047" Alignment="Bottom" />
+                <ControlPoint Id="IpMSLzGgPVwMZPbBGA5blz" Bounds="1080,841" Alignment="Top" />
+                <ControlPoint Id="NPg02mKQCehNQ1a9y7Go7f" Bounds="1235,1047" Alignment="Bottom" />
+                <ControlPoint Id="FwKbctbVBqqP2h7ScbH3Fy" Bounds="1235,841" Alignment="Top" />
+                <Patch Id="JW5nSNNltKbPmj6VGFtiLm" ManuallySortedPins="true">
+                  <Patch Id="OHmUd0hSRDRNpStjU5d3rx" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="LCnz1ntY4nLPdeDSl0GBdQ" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="1236,958,72,26" Id="VyfD21EO3ZmP24VkOOXdxT">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Games.GameTime" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="FrameCount" />
+                    </p:NodeReference>
+                    <Pin Id="BcFTmeSfSfUMJ4up95Kz2i" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="TH4GnIIJRtkMVFrRzLfsMQ" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="Ens0hr7dX2rMlNsAfW0seh" Name="Frame Count" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1233,918,70,26" Id="TS2InUheuNGL84VrWdeHhT">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderContext" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="RenderContext" />
+                      <Choice Kind="OperationCallFlag" Name="Time" />
+                    </p:NodeReference>
+                    <Pin Id="FEi8QSHH3nBOPgNbe0vsti" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="FC1NCXWhAgVLw14z5vwori" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="B6gePimeF7BNwCi2BrFD82" Name="Time" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1331,864,88,26" Id="M67RugZeRzROQMRBB7y5YC">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Rendering.RenderDrawContext" LastDependency="VL.Stride.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="RenderDrawContext" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="RenderContext" />
+                    </p:NodeReference>
+                    <Pin Id="ODkeFulBCe0Mysj3xmsKXs" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="LhGIJcBZxWiPc1YkWayura" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="LmW8N4SrakgOyck2CgUqsy" Name="Render Context" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1124,883,96,26" Id="CI3Kscbatl3ODY8qT4Yj0C">
+                    <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="GetFrameNumber" />
+                    </p:NodeReference>
+                    <Pin Id="JGOurSWOXWvPy1OAIL4HmX" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="PIib2sQLjrkPRLnNgoAdFa" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="RsvPWzAxI17MJMevV3n0PD" Name="Frame Number" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="1124,1006,25,19" Id="AnfKhT3dQTMM9lT5Sunjdp">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="&lt;" />
+                    </p:NodeReference>
+                    <Pin Id="OONBzYIWg0eNEX1CJG31jd" Name="Input" Kind="InputPin" />
+                    <Pin Id="UWQqR8NgAkHPUBP9liAwMg" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="J4npV9lSvbgOU4S454mdLs" Name="Result" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+              </Node>
+              <Node Bounds="1078,801,37,19" Id="OGL8Ixoj0I6N6RfQ6z73jt">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="NOT" />
+                </p:NodeReference>
+                <Pin Id="S8rWG1pCqqQNsVYCIC6B7N" Name="Input" Kind="StateInputPin" />
+                <Pin Id="Umg2Y0jf8fWPOZqbguB6SW" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <ControlPoint Id="UEheoMmBhpEMxSMPuG80Ct" Bounds="1233,1371" />
+              <Pad Id="O6QzbilCiKMM6Tdt3FxdcR" Bounds="1153,743,98,19" ShowValueBox="true" isIOBox="true" Value="Check if exists">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+                <p:ValueBoxSettings>
+                  <p:fontsize p:Type="Int32">9</p:fontsize>
+                  <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                </p:ValueBoxSettings>
+              </Pad>
+              <Pad Id="BXolapEXXe8NCyZ5akQm6k" Bounds="1364,1417,342,22" ShowValueBox="true" isIOBox="true" Value="Retrieve data if it doesnt exist or is from an older frame">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+                <p:ValueBoxSettings>
+                  <p:fontsize p:Type="Int32">9</p:fontsize>
+                  <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                </p:ValueBoxSettings>
+              </Pad>
+              <Pad Id="Ke9bfqimfL1LI54rRrxRTM" Bounds="1447,937,200,19" ShowValueBox="true" isIOBox="true" Value="Check if it is from current frame">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+                <p:ValueBoxSettings>
+                  <p:fontsize p:Type="Int32">9</p:fontsize>
+                  <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                </p:ValueBoxSettings>
+              </Pad>
+              <Pad Id="IhCBnUm6ZXEO1y49E717pb" Bounds="1553,1618,213,19" ShowValueBox="true" isIOBox="true" Value="Draw input with updated context">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+                <p:ValueBoxSettings>
+                  <p:fontsize p:Type="Int32">9</p:fontsize>
+                  <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                </p:ValueBoxSettings>
+              </Pad>
             </Canvas>
             <Patch Id="PYcVQQWp6PkPYTo8m9u9KV" Name="Create" />
             <ProcessDefinition Id="BsrycrTeJZ2QSp24BsEq5E" HasStateOut="true">
@@ -3104,25 +3121,49 @@
             <Patch Id="NVWQ07a49cROHCLR8dmmz5" Name="Update" ManuallySortedPins="true">
               <Pin Id="NLHRb9iLlutO0V1rXdc3B2" Name="Input" Kind="InputPin" />
             </Patch>
-            <Link Id="RPzj1m85K2TP43MJtR82sH" Ids="C8x51fcLrN1OS8lL4g9LJ5,DAT8KgXFqP5LykZU3v5buT" />
             <Link Id="NFhe6ZUSJdTNyyKRv2F7kC" Ids="Nx6K7kWkA87OtTB6bRmS1k,NpZSrwEZN5GOvO5HU8assO" />
             <Link Id="Uuf8eHCyasKPwn1A5U0BYP" Ids="K5oNmlJ0fOSMp4V5bX6uiJ,Nx6K7kWkA87OtTB6bRmS1k" />
             <Link Id="TkPJQgtcADdOVh3NJPU8Wq" Ids="NLHRb9iLlutO0V1rXdc3B2,K5oNmlJ0fOSMp4V5bX6uiJ" IsHidden="true" />
             <Link Id="OyMlH18CTwQO16tWsJV4XN" Ids="C8x51fcLrN1OS8lL4g9LJ5,Q1oJb8MLljLOQ6mgA1aVGD" />
             <Link Id="ULMxDEjPceePrWUJoRNI4D" Ids="EDRuTOkzYh6PRNnmbXMt0l,UeAxhYBk6PJNIKrLmNoWkc" />
-            <Link Id="NeaSsohgW9SNrEdbohxFxA" Ids="C1JV9EANnLvLpeklUutEFA,EtYP5E8bjrwPgefOxIONir" />
-            <Link Id="QKkzYibhMROPqPFsq11QIo" Ids="EWoOSpfJn8WLVInjrwqZe7,KxBUKEtfv0fOxAQDvjnjxZ" />
-            <Link Id="GZkDcpv7y99OTTljpHW2xi" Ids="J99x0MKAcmEPQEHl84ofJQ,EPlb5vrWJZ8P5VtmajBQ27" />
-            <Link Id="GTNwYnNdrSyPbIkAhThTS4" Ids="K3fuXPky3owOXIsRIqyPol,RATmuWYtZAEMPrtiEcPF30" />
             <Slot Id="TCuBmbFlbQ6PEmI1LLzLY6" Name="Compositor" />
             <Link Id="L9EtnIbTKkXMbnQcPmWhx4" Ids="S78rsCgoGA1LtdGfKVYSJJ,Ncu9UhXBddDQJbNOYVnmcN" />
             <Link Id="BouM5LQTWXTL7SBMFOSDSC" Ids="PERgaE6IPCxNcvWx4SVk8R,S78rsCgoGA1LtdGfKVYSJJ" />
             <Link Id="TdiD8Ae7yxXNcwDdoW9KX1" Ids="Qy3ohbILJQ8M3zGxlXFWIO,PERgaE6IPCxNcvWx4SVk8R" IsHidden="true" />
             <Link Id="PqRFATsehsnLps6mqtpBiW" Ids="FqV2QIIT2vsLlmwb3dzckZ,I7addska4f1OEFHYa3Gapr" />
-            <Link Id="MqHLTM6d7xEMkYluZgq8gy" Ids="FqV2QIIT2vsLlmwb3dzckZ,FZp5qnymERONLavHVZuT7J" />
             <Patch Id="OEB3dBZF9mXL28hxAJgn0c" Name="SetCompositor">
               <Pin Id="Qy3ohbILJQ8M3zGxlXFWIO" Name="Compositor" Kind="InputPin" />
             </Patch>
+            <Link Id="HfGqiQYTX3xMEsjHkKwEnT" Ids="Nx6K7kWkA87OtTB6bRmS1k,OiLBoODHrowOqNBXuizUrE" />
+            <Link Id="Apl09VJ6oFNMUwT98xudTM" Ids="TZQ2Hot5LNzPNBSybYBMtt,JvUSaK0Yr5UNeZ5crtundU" IsFeedback="true" />
+            <Link Id="ACJAvot9ZmMNjhzWFGmtAT" Ids="TZQ2Hot5LNzPNBSybYBMtt,JvUSaK0Yr5UNeZ5crtundU" />
+            <Link Id="QMkR5SKHrC8NdvVAmpkOXh" Ids="JvUSaK0Yr5UNeZ5crtundU,DAT8KgXFqP5LykZU3v5buT" />
+            <Link Id="USKsXmOMz1pPF3fRZTxcgy" Ids="FqV2QIIT2vsLlmwb3dzckZ,Vn9uP1EG9lzQIpZ950Kfzy" />
+            <Link Id="BgwhEKoYA2wOZ5P303wgTp" Ids="DvMM4qFNpUqNRz2r999upe,Ol8KVnkNK1WNgmwY1YZPWH" />
+            <Link Id="G4eRtWe41FaPR51MFK8duF" Ids="QnYylTDVqZvL20CCf6OwqT,BXzovYZWWJbQX9U0z42z9v" />
+            <Link Id="AhpgpNLk4VaP6av329j4xB" Ids="C1JV9EANnLvLpeklUutEFA,FekHGHekK2kPBqxiCawpnl" />
+            <Link Id="CWKtlOLRGtoLCq1aHkrjaH" Ids="B6gePimeF7BNwCi2BrFD82,BcFTmeSfSfUMJ4up95Kz2i" />
+            <Link Id="Plo3qZpr47DMdkaIONtytP" Ids="LmW8N4SrakgOyck2CgUqsy,FEi8QSHH3nBOPgNbe0vsti" />
+            <Link Id="MZvfeazx1QvQIMlM41oJUk" Ids="Ms1o8mpEhAYPHEw1Jb9xsF,IxqQrHJ91xJQcaGAqAQAz6" IsFeedback="true" />
+            <Link Id="FgHtgygIcT3MOv5FMa5v0a" Ids="C8x51fcLrN1OS8lL4g9LJ5,Ms1o8mpEhAYPHEw1Jb9xsF" />
+            <Link Id="VzTrD3Sql35MPFdNuMoqzw" Ids="Ms1o8mpEhAYPHEw1Jb9xsF,ODkeFulBCe0Mysj3xmsKXs" />
+            <Link Id="LUR0xxpsEcZNFlxy0ElNef" Ids="AKyDxhhOVjzMMKRZv0Shny,JGOurSWOXWvPy1OAIL4HmX" />
+            <Link Id="A6PyY6lbChFMhoZ5wP1tcT" Ids="IpMSLzGgPVwMZPbBGA5blz,RaIamlQu0lVLjqhiC6KrW7" IsFeedback="true" />
+            <Link Id="JYWUgX8ZIQwLFd8JlrdAlz" Ids="J4npV9lSvbgOU4S454mdLs,RaIamlQu0lVLjqhiC6KrW7" />
+            <Link Id="VkjUUUzV0zWOZ2qtPeVRL4" Ids="RaIamlQu0lVLjqhiC6KrW7,KxBUKEtfv0fOxAQDvjnjxZ" />
+            <Link Id="JCWB4ghJmzNLKRJJIrApF0" Ids="LhGIJcBZxWiPc1YkWayura,IxqQrHJ91xJQcaGAqAQAz6" />
+            <Link Id="HjkKMQLKwVWLJQnVKF2foM" Ids="IxqQrHJ91xJQcaGAqAQAz6,TZQ2Hot5LNzPNBSybYBMtt" />
+            <Link Id="SRsvCORpANTNAbNuMNVz4T" Ids="K3fuXPky3owOXIsRIqyPol,TC03cat8lzlM4YFcqgsVdJ" />
+            <Link Id="PcUki57oSl5PffPeGZwGn9" Ids="QBMTr7t38mwQb0zIwpiTUc,NIljp4eBBPNP2GU9WODEJ1" />
+            <Link Id="RhgM81wgd7jNV8MyXpjGts" Ids="C1JV9EANnLvLpeklUutEFA,S8rWG1pCqqQNsVYCIC6B7N" />
+            <Link Id="UIzCHjNzZqjNmcub4aC3jB" Ids="Umg2Y0jf8fWPOZqbguB6SW,IpMSLzGgPVwMZPbBGA5blz" />
+            <Link Id="N7o4dKp4MFTPke3gPkNF0F" Ids="FwKbctbVBqqP2h7ScbH3Fy,NPg02mKQCehNQ1a9y7Go7f" IsFeedback="true" />
+            <Link Id="AolXBksIxTvLwLNyKdA8dl" Ids="TZQ2Hot5LNzPNBSybYBMtt,MwgFzhiXztSLQqBcYbesIA,MAjVz8F1ql9QDHa5ZxitCk" />
+            <Link Id="Hjm3NBljt4wNiP0gAzG6t9" Ids="Ens0hr7dX2rMlNsAfW0seh,NPg02mKQCehNQ1a9y7Go7f" />
+            <Link Id="GQbiZp4BvxUL9kflmcUoeW" Ids="RsvPWzAxI17MJMevV3n0PD,OONBzYIWg0eNEX1CJG31jd" />
+            <Link Id="QXhsLCt9avZNaGJMwLx2p4" Ids="Ens0hr7dX2rMlNsAfW0seh,UWQqR8NgAkHPUBP9liAwMg" />
+            <Link Id="SASFtIuQWYCPxnr72vAd6v" Ids="J99x0MKAcmEPQEHl84ofJQ,EPlb5vrWJZ8P5VtmajBQ27" />
+            <Link Id="GybzmbD4ufDMmrqFjCRvBj" Ids="NPg02mKQCehNQ1a9y7Go7f,UEheoMmBhpEMxSMPuG80Ct,M00kkHOXfOeLZnk4sJZKDQ" />
           </Patch>
         </Node>
         <!--
@@ -3130,12 +3171,12 @@
     ************************ ShadowCatcherDataKey ************************
 
 -->
-        <Node Name="ShadowCatcherDataKey" Bounds="1009,449,281,211" Id="NI2usixxVXaLQGQ59UGE1z">
+        <Node Name="ShadowCatcherDataKey" Bounds="984,309,281,327" Id="NI2usixxVXaLQGQ59UGE1z">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="AjQ7cRqNCwNMnPmhAc8q1R">
-            <Node Bounds="1090,469,188,129" Id="IYoj0iIy2VoPTEVdfu3xR7">
+            <Node Bounds="1065,329,188,245" Id="IYoj0iIy2VoPTEVdfu3xR7">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -3146,8 +3187,8 @@
               <Pin Id="RjyLbVtklzOLBLb1xsgeyP" Name="Singleton" Kind="OutputPin" />
               <Patch Id="LAdt2gNSIYeL5AINZnPpLb" Name="Producer" ManuallySortedPins="true">
                 <Pin Id="AKixyhlpvfkNlWjgFf3S6N" Name="Result" Kind="OutputPin" />
-                <ControlPoint Id="D7VXX4CEhKeLYU4GrkPfSK" Bounds="1106,591" />
-                <Node Bounds="1103,533,68,26" Id="BxItyliUiQCQV1G6EKzCE7">
+                <ControlPoint Id="D7VXX4CEhKeLYU4GrkPfSK" Bounds="1083,567" />
+                <Node Bounds="1080,468,68,26" Id="BxItyliUiQCQV1G6EKzCE7">
                   <p:NodeReference LastCategoryFullName="Stride.Core.PropertyKey`1" LastDependency="Stride.Core.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="PropertyKey`1" />
@@ -3158,15 +3199,37 @@
                   <Pin Id="E3lB4PIFYURPau9Fpm82Sa" Name="Metadatas" Kind="InputPin" />
                   <Pin Id="BFSPovEUcCYPnLT9wAmgbS" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="Q6v2cnWsi0NLsnUzeDoP4j" Comment="Name" Bounds="1106,497,112,15" ShowValueBox="true" isIOBox="true" Value="ShadowCatcherData">
+                <Pad Id="Q6v2cnWsi0NLsnUzeDoP4j" Comment="Name" Bounds="1081,357,112,15" ShowValueBox="true" isIOBox="true" Value="ShadowCatcherData">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
+                <Node Bounds="1111,386,87,26" Id="QFjXurimQnMOc1F4kTAyOm">
+                  <p:NodeReference LastCategoryFullName="ShadowCatcher.ShadowCatcherData" LastDependency="VL.ShadowCatcher.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="ShadowCatcherData" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="Fr8YpJzG7FAMxHrzHAqHHu" Name="ShadowMap" Kind="InputPin" />
+                  <Pin Id="D1EHjCHjYW1MIeb2ZoqYGC" Name="Buffers" Kind="InputPin" />
+                  <Pin Id="QntAd1CruAvNErLLCAFB8A" Name="Directional Light Count" Kind="InputPin" />
+                  <Pin Id="DrOJdR95ReTOWFsaYflfVu" Name="Spot Light Count" Kind="InputPin" />
+                  <Pin Id="KUO840BRAFJLpakQTiHbDB" Name="Point Light Count" Kind="InputPin" />
+                  <Pin Id="MVHZFedc3GAPzxSdfEsQk8" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1111,428,54,26" Id="N2v8nWff0vWQRjmcyiwYEH">
+                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetType" />
+                  </p:NodeReference>
+                  <Pin Id="PYdDSwQbP5UN8IMZads6w7" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Q4eBN3bvGyAPdjI8vvpnNp" Name="Output" Kind="StateOutputPin" />
+                </Node>
               </Patch>
             </Node>
             <Link Id="ILQC2bEJFZULEywwYn2C3W" Ids="D7VXX4CEhKeLYU4GrkPfSK,AKixyhlpvfkNlWjgFf3S6N" IsHidden="true" />
-            <ControlPoint Id="NuC8XKO5cVwQB9oWu0ko5S" Bounds="1092,643" />
+            <ControlPoint Id="NuC8XKO5cVwQB9oWu0ko5S" Bounds="1067,619" />
             <Link Id="MLqN2hRVsBYN7noVvCt79s" Ids="RjyLbVtklzOLBLb1xsgeyP,NuC8XKO5cVwQB9oWu0ko5S" />
             <Link Id="FO3XUa2x96uLTjq5RSxv5k" Ids="NuC8XKO5cVwQB9oWu0ko5S,Nk71fm9yjMWN89P1lhVepj" IsHidden="true" />
             <Link Id="NpGzsnwqvNXLSDBeAypEwu" Ids="BFSPovEUcCYPnLT9wAmgbS,D7VXX4CEhKeLYU4GrkPfSK" />
@@ -3181,6 +3244,8 @@
                 </p:TypeArguments>
               </p:TypeAnnotation>
             </Pin>
+            <Link Id="Sz1p4e5HH2FPS22g7KR5BO" Ids="MVHZFedc3GAPzxSdfEsQk8,PYdDSwQbP5UN8IMZads6w7" />
+            <Link Id="QDfKYZsdS7AMALfh0h4pvn" Ids="Q4eBN3bvGyAPdjI8vvpnNp,GaCJG6S4VPtLN9sUjtLCNl" />
           </Patch>
         </Node>
       </Canvas>
@@ -3206,7 +3271,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="GOJilsPYjshQcKnEHDpYlN" Location="VL.Stride" Version="2023.5.0" />
+  <NugetDependency Id="GOJilsPYjshQcKnEHDpYlN" Location="VL.Stride" Version="2023.5.2" />
   <PlatformDependency Id="B9QxKRqJYwTNW107F3zyzE" Location="Stride.Engine.dll" />
   <PlatformDependency Id="Lw3p7rP4oXGLAaZAfvAlUI" Location="Stride.Rendering.dll" />
   <NugetDependency Id="TUXfXeIzYfFLAjZcHPYqnS" Location="System.Reflection" Version="4.3.0" />
@@ -3216,4 +3281,7 @@
   <PlatformDependency Id="H8QoLOXLVHvMez5AIlsGT6" Location="./lib/netstandard2.0/VL.ShadowCatcher.dll" />
   <NodeFactoryDependency Id="HMpR4NUNHezLShcXRJkXKY" Location="VL.Stride.Engine.Nodes" />
   <PlatformDependency Id="Gb8QXrxIMD1LK03bsgSoqc" Location="Stride.Rendering.dll" />
+  <PlatformDependency Id="VGH9llAHCJmNy4pJgTdPAV" Location="Stride.Core.dll" />
+  <PlatformDependency Id="K1G9BZxPZ4iNNuMWUkVu6h" Location="Stride.Core.dll" />
+  <PlatformDependency Id="VxYuIWclHNzNWp9QVtdcv4" Location="Stride.Core.dll" />
 </Document>

--- a/help/HowTo Draw Shadow Catcher.vl
+++ b/help/HowTo Draw Shadow Catcher.vl
@@ -186,12 +186,11 @@
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="737,766,225,19" Id="AOZEedSsx1TPgnX9mfAhJ4">
-            <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <CategoryReference Kind="Category" Name="ShadowCatcher" NeedsToBeDirectParent="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="2944.6667, 154.66667, 822, 932.6667" />
+            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="2483.3333, 294, 786, 432" />
             <Pin Id="TRUphtXCHCwPn2p8Huccrz" Name="Input" Kind="InputPin" />
             <Pin Id="EOnh7I5nsQmLDLdytraRBl" Name="Camera" Kind="InputPin" />
             <Pin Id="GZ4JQQ3REgRPScpU6UD4LZ" Name="Enable Default Camera" Kind="InputPin" />
@@ -204,7 +203,8 @@
             <Pin Id="SMJtegPfKZbNy9HHeF7hnJ" Name="Enabled" Kind="InputPin" />
             <Pin Id="JoMgbgMn0E6Oyx7OqFIJZY" Name="Present Interval" Kind="InputPin" DefaultValue="Default" />
             <Pin Id="MQAHncXX6YdLnS4DLN0paH" Name="Output" Kind="OutputPin" />
-            <Pin Id="IdIaa1BS2txP1GGlB6S8nj" Name="Compositor" Kind="OutputPin" />
+            <Pin Id="TeSeQVUTqXJLhWxoAeuVcC" Name="Client Bounds" Kind="OutputPin" />
+            <Pin Id="O0ZMOCWDwc6LC3suim6hg1" Name="Input Source" Kind="OutputPin" />
           </Node>
           <Node Bounds="244,299,125,19" Id="Mv9EPSJg5V4PrrGMkWY4GC">
             <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
@@ -473,7 +473,7 @@
             <Pin Id="EWoNMedmYrhLbZH8i2hXly" Name="Input" Kind="StateInputPin" />
             <Pin Id="MMC0lrjH9nHQMzkxFscg8x" Name="Output" Kind="StateOutputPin" />
           </Node>
-          <Node Bounds="210,343,125,19" Id="D5c4pRzixFKOOZJZc5EpRn">
+          <Node Bounds="210,343,86,19" Id="D5c4pRzixFKOOZJZc5EpRn">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
@@ -482,11 +482,10 @@
             <Pin Id="Tz9u9eVy4yGQIsuRLDUVKK" Name="Mesh" Kind="InputPin" />
             <Pin Id="ByiKACIuIqnQDHd1EdN5wu" Name="Light Attenuation" Kind="InputPin" />
             <Pin Id="RgEQRE4gBtYOk9BqXkzdVl" Name="Shadow Tint" Kind="InputPin" />
-            <Pin Id="McEyZObtYyKPbnu8wsjGNY" Name="Compositor" Kind="InputPin" />
             <Pin Id="ED9KyHuvqOxQX3WhmvRzHD" Name="Enabled" Kind="InputPin" />
             <Pin Id="L5KCskD6y0AL4SUAnNtqtD" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="-12,340,145,19" Id="GqCMYssFWLrNuPDUrbUwZH">
+          <Node Bounds="-12,340,105,19" Id="GqCMYssFWLrNuPDUrbUwZH">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
@@ -496,7 +495,6 @@
             <Pin Id="NYrKYBe6wjbLKDdjwnhciV" Name="Light Attenuation" Kind="InputPin" />
             <Pin Id="K23xhI6fieRONeH9VNVc07" Name="Shadow Tint" Kind="InputPin" />
             <Pin Id="Tk7l4urU0G7PlVwgyLXg29" Name="Normal Offset" Kind="InputPin" />
-            <Pin Id="HeYZpCXn3PNLdmPnEY1wCe" Name="Compositor" Kind="InputPin" />
             <Pin Id="R4DwocibzfwM3gblCdr0ie" Name="Enabled" Kind="InputPin" />
             <Pin Id="T0feYkj4NlvQUle455rx75" Name="Output" Kind="OutputPin" />
           </Node>
@@ -600,17 +598,6 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="B18ey10dhvpQbQ729C43jX" SlotId="PTSVhPTdBp0Mh8G2gktRvt" Bounds="959,828" />
-          <Pad Id="RsKsAgxVXvfLKgNBVV2nh7" SlotId="PTSVhPTdBp0Mh8G2gktRvt" Bounds="485,277" />
-          <Pad Id="SQ7QoLAybgQMdh1epl7DwF" Bounds="984,751,447,114" ShowValueBox="true" isIOBox="true" Value="1. Use this project's own SceneWindow (or yours!) with added Compositor output to get the data needed for render Shadow Catcher and store it to the Pad.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="String" />
-            </p:TypeAnnotation>
-            <p:ValueBoxSettings>
-              <p:fontsize p:Type="Int32">13</p:fontsize>
-              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-            </p:ValueBoxSettings>
-          </Pad>
           <Pad Id="NIGZ628EnLdL7lxY3VwM5b" Bounds="-60,-473,390,69" ShowValueBox="true" isIOBox="true" Value="2. Render ShadowCatcher using Compositor and GetShadowParameters.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
@@ -637,15 +624,6 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="ViAvH5PGswYNq8O6ijji2K" Bounds="-488,186,390,69" ShowValueBox="true" isIOBox="true" Value="Only direct shadows from shadow mapping are rendered here.">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="String" />
-            </p:TypeAnnotation>
-            <p:ValueBoxSettings>
-              <p:fontsize p:Type="Int32">13</p:fontsize>
-              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-            </p:ValueBoxSettings>
-          </Pad>
-          <Pad Id="FanqzeQg0aqM3ohA012Dif" Bounds="-486,271,389,137" ShowValueBox="true" isIOBox="true" Value="As a known issue, ShadowCatcher renders the result with a 1 frame delay because the shadow data is retrieved in vvvv's Update operation.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -967,8 +945,6 @@
         <Link Id="KDSr3csVAOLM37y3BthF5m" Ids="MIGcwRcltQ6LP3CU2j4YY8,NtKp3CXaFXBOqWBXMhmbh3" />
         <Link Id="VEWYeXZAIQfL7WX0SH1HbD" Ids="FPT8NPoN8UCL2gHnVc26nW,TRUphtXCHCwPn2p8Huccrz" />
         <Link Id="ISC86bNTnJsOiXR9PrTWzr" Ids="PZfvY0sm90uPsjhGJzBtFR,AEIFlF0DlvFQMaafGF8QMQ" />
-        <Slot Id="PTSVhPTdBp0Mh8G2gktRvt" Name="Compositor" />
-        <Link Id="QvcKjcgmrz2PjxT2OW2zKC" Ids="IdIaa1BS2txP1GGlB6S8nj,B18ey10dhvpQbQ729C43jX" />
         <Link Id="R7HV8a8AznGL5X05FH8Ph6" Ids="Tw2DIJETS1mNrmbLjvh3SF,Tf1QRPqsROEQZN95tDc5fO" />
         <Link Id="T0mJCGXPQcBPO4jfipGyS7" Ids="HXYxhms6g5NLb7arQhYgAs,RgEQRE4gBtYOk9BqXkzdVl" />
         <Link Id="PUH8OTcezCJK93GiMQOaNY" Ids="T0feYkj4NlvQUle455rx75,EugrrTPzkzfQLgqxOmjfaK" />
@@ -1013,8 +989,6 @@
         <Link Id="RWbyh0RKuU2NH3ujOuzt7d" Ids="KWl4PnLXW16O5gx4D0Agdg,RNOMzbEh39UMSskBZy5qBH" />
         <Link Id="Mx3iyVqL6yeMydMCJ5eVFZ" Ids="ElrGqxZMH8bL2PcdjdAHy0,QWMszTUznCvP7cf962J15I" />
         <Link Id="Fw2wvqSGt2INgDimM4Cx74" Ids="Tkk8BL0XxElOe65hx2AMIM,ThIBJkHxQ5OPwnTTjcuEHP" />
-        <Link Id="PlTJjlBKHDLQb9Ey6XnGuS" Ids="RsKsAgxVXvfLKgNBVV2nh7,HeYZpCXn3PNLdmPnEY1wCe" />
-        <Link Id="TbIvGEuqSH7PTcg0JljCzE" Ids="RsKsAgxVXvfLKgNBVV2nh7,McEyZObtYyKPbnu8wsjGNY" />
       </Patch>
     </Node>
   </Patch>

--- a/help/HowTo Draw Shadow Catcher.vl
+++ b/help/HowTo Draw Shadow Catcher.vl
@@ -191,7 +191,7 @@
               <CategoryReference Kind="Category" Name="ShadowCatcher" NeedsToBeDirectParent="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="1038, 84, 822, 933" />
+            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="2944.6667, 154.66667, 822, 932.6667" />
             <Pin Id="TRUphtXCHCwPn2p8Huccrz" Name="Input" Kind="InputPin" />
             <Pin Id="EOnh7I5nsQmLDLdytraRBl" Name="Camera" Kind="InputPin" />
             <Pin Id="GZ4JQQ3REgRPScpU6UD4LZ" Name="Enable Default Camera" Kind="InputPin" />
@@ -205,14 +205,6 @@
             <Pin Id="JoMgbgMn0E6Oyx7OqFIJZY" Name="Present Interval" Kind="InputPin" DefaultValue="Default" />
             <Pin Id="MQAHncXX6YdLnS4DLN0paH" Name="Output" Kind="OutputPin" />
             <Pin Id="IdIaa1BS2txP1GGlB6S8nj" Name="Compositor" Kind="OutputPin" />
-          </Node>
-          <Node Bounds="-104,-379,117,19" Id="RSW9scpl7YhPHaSZGPrxXk">
-            <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="GetShadowParameters" />
-            </p:NodeReference>
-            <Pin Id="NlU7pAgueSrM95eKDugVxF" Name="Input" Kind="InputPin" />
-            <Pin Id="E8KlpJ3PG4LOx82vPlPosy" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="244,299,125,19" Id="Mv9EPSJg5V4PrrGMkWY4GC">
             <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
@@ -481,30 +473,30 @@
             <Pin Id="EWoNMedmYrhLbZH8i2hXly" Name="Input" Kind="StateInputPin" />
             <Pin Id="MMC0lrjH9nHQMzkxFscg8x" Name="Output" Kind="StateOutputPin" />
           </Node>
-          <Node Bounds="210,343,105,19" Id="D5c4pRzixFKOOZJZc5EpRn">
+          <Node Bounds="210,343,125,19" Id="D5c4pRzixFKOOZJZc5EpRn">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
             </p:NodeReference>
             <Pin Id="K1TGLovqAUOLLWNodWSxSg" Name="Transformation" Kind="InputPin" />
-            <Pin Id="FHtCiVrz4exLyIIc8ARApX" Name="ShadowCatcher Data" Kind="InputPin" />
             <Pin Id="Tz9u9eVy4yGQIsuRLDUVKK" Name="Mesh" Kind="InputPin" />
             <Pin Id="ByiKACIuIqnQDHd1EdN5wu" Name="Light Attenuation" Kind="InputPin" />
             <Pin Id="RgEQRE4gBtYOk9BqXkzdVl" Name="Shadow Tint" Kind="InputPin" />
+            <Pin Id="McEyZObtYyKPbnu8wsjGNY" Name="Compositor" Kind="InputPin" />
             <Pin Id="ED9KyHuvqOxQX3WhmvRzHD" Name="Enabled" Kind="InputPin" />
             <Pin Id="L5KCskD6y0AL4SUAnNtqtD" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="-12,340,125,19" Id="GqCMYssFWLrNuPDUrbUwZH">
+          <Node Bounds="-12,340,145,19" Id="GqCMYssFWLrNuPDUrbUwZH">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
             </p:NodeReference>
             <Pin Id="BDZeBGGnaFJNFKYZZIl0TB" Name="Transformation" Kind="InputPin" />
-            <Pin Id="BGiZXuRrW4nP4SbnZwYJg8" Name="ShadowCatcher Data" Kind="InputPin" />
             <Pin Id="QlvHA9CnNRnLefU7meFa2f" Name="Mesh" Kind="InputPin" />
             <Pin Id="NYrKYBe6wjbLKDdjwnhciV" Name="Light Attenuation" Kind="InputPin" />
             <Pin Id="K23xhI6fieRONeH9VNVc07" Name="Shadow Tint" Kind="InputPin" />
             <Pin Id="Tk7l4urU0G7PlVwgyLXg29" Name="Normal Offset" Kind="InputPin" />
+            <Pin Id="HeYZpCXn3PNLdmPnEY1wCe" Name="Compositor" Kind="InputPin" />
             <Pin Id="R4DwocibzfwM3gblCdr0ie" Name="Enabled" Kind="InputPin" />
             <Pin Id="T0feYkj4NlvQUle455rx75" Name="Output" Kind="OutputPin" />
           </Node>
@@ -520,7 +512,7 @@
             <Pin Id="MEgTluqDy1mQaAURAfppg4" Name="Number Of Texture Coordinates" Kind="InputPin" />
             <Pin Id="NqfsoIjLTp2NvNFc17zzlt" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="92,420,105,19" Id="IQELxTg8dV5MN8ljBbaYCV">
+          <Node Bounds="172,537,105,19" Id="IQELxTg8dV5MN8ljBbaYCV">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -609,7 +601,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="B18ey10dhvpQbQ729C43jX" SlotId="PTSVhPTdBp0Mh8G2gktRvt" Bounds="959,828" />
-          <Pad Id="RsKsAgxVXvfLKgNBVV2nh7" SlotId="PTSVhPTdBp0Mh8G2gktRvt" Bounds="-103,-435" />
+          <Pad Id="RsKsAgxVXvfLKgNBVV2nh7" SlotId="PTSVhPTdBp0Mh8G2gktRvt" Bounds="485,277" />
           <Pad Id="SQ7QoLAybgQMdh1epl7DwF" Bounds="984,751,447,114" ShowValueBox="true" isIOBox="true" Value="1. Use this project's own SceneWindow (or yours!) with added Compositor output to get the data needed for render Shadow Catcher and store it to the Pad.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
@@ -912,7 +904,7 @@
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="HKL3bTUWa3lP5BXMkCa6sX" Comment="Normal Offset" Bounds="89,304,45,15" ShowValueBox="true" isIOBox="true" Value="0.001">
+          <Pad Id="HKL3bTUWa3lP5BXMkCa6sX" Comment="Normal Offset" Bounds="84,301,45,15" ShowValueBox="true" isIOBox="true" Value="0.001">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -962,9 +954,7 @@
         <Link Id="TapKgLNieGALAjzhnVRMFr" Ids="ToOEYQ2IpnPPqXf14xl2gE,T3DZHm6Y2EcM4fzbj0Qdax" />
         <Link Id="CZWMgxqjvyAOldXqc1OQ5C" Ids="GuKDOheAjILLn4J5ZLHrLo,OX46F8CvfzNLbIjRXnYKdc" />
         <Link Id="S5Wgr2I5aRKQRlgsBhoD4N" Ids="LtikeCWmiNlO2xF1HR5kb6,EWoNMedmYrhLbZH8i2hXly" />
-        <Link Id="Dw1C6NtmFXoPD1nxRaEJyP" Ids="E8KlpJ3PG4LOx82vPlPosy,FHtCiVrz4exLyIIc8ARApX" />
         <Link Id="QTsblduw8wzNt6qwf4ylZz" Ids="OKvPoreXgvbNARyrwgGGlx,Tz9u9eVy4yGQIsuRLDUVKK" />
-        <Link Id="EJoGBavuVF7OfWdtHhevxm" Ids="E8KlpJ3PG4LOx82vPlPosy,BGiZXuRrW4nP4SbnZwYJg8" />
         <Link Id="TyBjDy7xsJ6QKm2vDFK13h" Ids="NqfsoIjLTp2NvNFc17zzlt,QlvHA9CnNRnLefU7meFa2f" />
         <Link Id="UoNcAANMgquQExGHUQUtW1" Ids="HXYxhms6g5NLb7arQhYgAs,K23xhI6fieRONeH9VNVc07" />
         <Link Id="Vq6nh2nfJjuL9PNK0jMeeN" Ids="MIGcwRcltQ6LP3CU2j4YY8,BDZeBGGnaFJNFKYZZIl0TB" />
@@ -979,7 +969,6 @@
         <Link Id="ISC86bNTnJsOiXR9PrTWzr" Ids="PZfvY0sm90uPsjhGJzBtFR,AEIFlF0DlvFQMaafGF8QMQ" />
         <Slot Id="PTSVhPTdBp0Mh8G2gktRvt" Name="Compositor" />
         <Link Id="QvcKjcgmrz2PjxT2OW2zKC" Ids="IdIaa1BS2txP1GGlB6S8nj,B18ey10dhvpQbQ729C43jX" />
-        <Link Id="HPgXYwUHjh2OjMUiXd0XgP" Ids="RsKsAgxVXvfLKgNBVV2nh7,NlU7pAgueSrM95eKDugVxF" />
         <Link Id="R7HV8a8AznGL5X05FH8Ph6" Ids="Tw2DIJETS1mNrmbLjvh3SF,Tf1QRPqsROEQZN95tDc5fO" />
         <Link Id="T0mJCGXPQcBPO4jfipGyS7" Ids="HXYxhms6g5NLb7arQhYgAs,RgEQRE4gBtYOk9BqXkzdVl" />
         <Link Id="PUH8OTcezCJK93GiMQOaNY" Ids="T0feYkj4NlvQUle455rx75,EugrrTPzkzfQLgqxOmjfaK" />
@@ -1024,6 +1013,8 @@
         <Link Id="RWbyh0RKuU2NH3ujOuzt7d" Ids="KWl4PnLXW16O5gx4D0Agdg,RNOMzbEh39UMSskBZy5qBH" />
         <Link Id="Mx3iyVqL6yeMydMCJ5eVFZ" Ids="ElrGqxZMH8bL2PcdjdAHy0,QWMszTUznCvP7cf962J15I" />
         <Link Id="Fw2wvqSGt2INgDimM4Cx74" Ids="Tkk8BL0XxElOe65hx2AMIM,ThIBJkHxQ5OPwnTTjcuEHP" />
+        <Link Id="PlTJjlBKHDLQb9Ey6XnGuS" Ids="RsKsAgxVXvfLKgNBVV2nh7,HeYZpCXn3PNLdmPnEY1wCe" />
+        <Link Id="TbIvGEuqSH7PTcg0JljCzE" Ids="RsKsAgxVXvfLKgNBVV2nh7,McEyZObtYyKPbnu8wsjGNY" />
       </Patch>
     </Node>
   </Patch>

--- a/help/HowTo Draw Shadow Catcher.vl
+++ b/help/HowTo Draw Shadow Catcher.vl
@@ -15,7 +15,7 @@
       </p:NodeReference>
       <Patch Id="LhDGs97QfiAPYDTmslZT3t">
         <Canvas Id="GZwasPPyRCENp5piM0RAXI" CanvasType="Group">
-          <Node Bounds="758,716,65,19" Id="Pi9gPSomOynLsVqGOx2Y5u">
+          <Node Bounds="1259,1273,65,19" Id="Pi9gPSomOynLsVqGOx2Y5u">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -27,7 +27,7 @@
             <Pin Id="IRMpsJIqOKOMl19IHmjPAf" Name="Enabled" Kind="InputPin" />
             <Pin Id="FPT8NPoN8UCL2gHnVc26nW" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1530,9,185,19" Id="NA8urNYAQerP85fOXCEaRa">
+          <Node Bounds="2031,566,185,19" Id="NA8urNYAQerP85fOXCEaRa">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
@@ -44,7 +44,7 @@
             <Pin Id="HtFH8bFAFTpLnhh4rWR4Fl" Name="Enabled" Kind="InputPin" />
             <Pin Id="FShOj7xxBidPQYJrer47Mw" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Node Bounds="647,197,80,19" Id="BB8vFnSzFHUMlkX95jQTKP">
+          <Node Bounds="1148,754,80,19" Id="BB8vFnSzFHUMlkX95jQTKP">
             <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -58,12 +58,12 @@
             <Pin Id="KXfVyEZKkcqLcL9CzivGnJ" Name="Translation" Kind="InputPin" />
             <Pin Id="IkC644wpGarL9PNFbvHmoE" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="GW3w8ccbeJ7PHwM4ciDbpB" Comment="Translation" Bounds="722,132,35,43" ShowValueBox="true" isIOBox="true" Value="0, 3.18, 0">
+          <Pad Id="GW3w8ccbeJ7PHwM4ciDbpB" Comment="Translation" Bounds="1223,689,35,43" ShowValueBox="true" isIOBox="true" Value="0, 3.18, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1959,2,245,19" Id="Dp8wlYJiUd5LcQFXeMAh0J">
+          <Node Bounds="2460,559,245,19" Id="Dp8wlYJiUd5LcQFXeMAh0J">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SpotLight" />
@@ -83,7 +83,7 @@
             <Pin Id="Ifk2P8eKA3gMBMBzfJJfNu" Name="Enabled" Kind="InputPin" />
             <Pin Id="Q9alDCEQugUQaCqchMMRXq" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1544,506,165,19" Id="Eual2EzguHsP7xmlCSCNBK">
+          <Node Bounds="2045,1063,165,19" Id="Eual2EzguHsP7xmlCSCNBK">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -100,17 +100,17 @@
             <Pin Id="Tv9lRYrKEIuLFJbJQsRh1Y" Name="Enabled" Kind="InputPin" />
             <Pin Id="PZfvY0sm90uPsjhGJzBtFR" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="Rc83OBJchh0QdgYT5hnBia" Comment="Position" Bounds="1908,-139,40,43" ShowValueBox="true" isIOBox="true" Value="-3.67, 1.96, 2.7">
+          <Pad Id="Rc83OBJchh0QdgYT5hnBia" Comment="Position" Bounds="2409,418,40,43" ShowValueBox="true" isIOBox="true" Value="-3.67, 1.96, 2.7">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="GpSQMfgOUFXMLE1NTFRvU5" Comment="Intensity" Bounds="2099,-161,35,15" ShowValueBox="true" isIOBox="true" Value="3.58">
+          <Pad Id="GpSQMfgOUFXMLE1NTFRvU5" Comment="Intensity" Bounds="2600,396,35,15" ShowValueBox="true" isIOBox="true" Value="3.58">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="935,261,205,19" Id="IzJWG3AWNp1QCRVFoiWfpS">
+          <Node Bounds="1436,818,205,19" Id="IzJWG3AWNp1QCRVFoiWfpS">
             <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Plane" />
@@ -128,12 +128,12 @@
             <Pin Id="Rksao8dmfLGNxnrelBf3NH" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="HA11WrJkW5UM6Xk2PFyfUu" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="CVfLOmrLKrgPNlQtaX9NyY" Comment="Target" Bounds="1967,-88,35,43" ShowValueBox="true" isIOBox="true" Value="-0.37, -2.46, -2.42">
+          <Pad Id="CVfLOmrLKrgPNlQtaX9NyY" Comment="Target" Bounds="2468,469,35,43" ShowValueBox="true" isIOBox="true" Value="-0.37, -2.46, -2.42">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="2107,311,245,19" Id="P5xxHpJ1YYMNrTWznXkTKT">
+          <Node Bounds="2608,868,245,19" Id="P5xxHpJ1YYMNrTWznXkTKT">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SpotLight" />
@@ -153,12 +153,12 @@
             <Pin Id="DiTguxYcwvoPn9stYPzw6o" Name="Enabled" Kind="InputPin" />
             <Pin Id="M5foiCwlj8hMX9bAN0nlcN" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="MfclXdIGPIoNnyket4WNGy" Comment="Target" Bounds="1588,-67,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0, 0">
+          <Pad Id="MfclXdIGPIoNnyket4WNGy" Comment="Target" Bounds="2089,490,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1682,268,185,19" Id="DKrnzp8jcMsLQ8qeWY750s">
+          <Node Bounds="2183,825,185,19" Id="DKrnzp8jcMsLQ8qeWY750s">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
@@ -175,22 +175,22 @@
             <Pin Id="FiON4GrY8K2MQmbQjg6Tre" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="KWl4PnLXW16O5gx4D0Agdg" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="BsheFODXVxaNVDkv1OtmXA" Comment="Range" Bounds="2083,-79,35,15" ShowValueBox="true" isIOBox="true" Value="11.18">
+          <Pad Id="BsheFODXVxaNVDkv1OtmXA" Comment="Range" Bounds="2584,478,35,15" ShowValueBox="true" isIOBox="true" Value="11.18">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="N5p9rgwCpOJPupWQ8FHhrc" Comment="Angle" Bounds="2150,-49,35,15" ShowValueBox="true" isIOBox="true" Value="0.38">
+          <Pad Id="N5p9rgwCpOJPupWQ8FHhrc" Comment="Angle" Bounds="2651,508,35,15" ShowValueBox="true" isIOBox="true" Value="0.38">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="737,766,225,19" Id="AOZEedSsx1TPgnX9mfAhJ4">
+          <Node Bounds="1238,1323,225,19" Id="AOZEedSsx1TPgnX9mfAhJ4">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="2483.3333, 294, 786, 432" />
+            <Pin Id="EuFomNxZOHwMkn8ARy01wj" Name="Bounds" Kind="InputPin" DefaultValue="1388, 105.333336, 786, 432" />
             <Pin Id="TRUphtXCHCwPn2p8Huccrz" Name="Input" Kind="InputPin" />
             <Pin Id="EOnh7I5nsQmLDLdytraRBl" Name="Camera" Kind="InputPin" />
             <Pin Id="GZ4JQQ3REgRPScpU6UD4LZ" Name="Enable Default Camera" Kind="InputPin" />
@@ -206,7 +206,7 @@
             <Pin Id="TeSeQVUTqXJLhWxoAeuVcC" Name="Client Bounds" Kind="OutputPin" />
             <Pin Id="O0ZMOCWDwc6LC3suim6hg1" Name="Input Source" Kind="OutputPin" />
           </Node>
-          <Node Bounds="244,299,125,19" Id="Mv9EPSJg5V4PrrGMkWY4GC">
+          <Node Bounds="745,856,125,19" Id="Mv9EPSJg5V4PrrGMkWY4GC">
             <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="PlaneMesh" />
@@ -220,7 +220,7 @@
             <Pin Id="ROGo5mEGkAqP5D3OgZhmaV" Name="Number Of Texture Coordinates" Kind="InputPin" />
             <Pin Id="OKvPoreXgvbNARyrwgGGlx" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="931,223,80,19" Id="BmLTXtPBqAdMgfKEKhIVVf">
+          <Node Bounds="1432,780,80,19" Id="BmLTXtPBqAdMgfKEKhIVVf">
             <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -234,37 +234,37 @@
             <Pin Id="R6OtK52h2NZOU1d13MENZJ" Name="Translation" Kind="InputPin" DefaultValue="0, -0.008, 0" />
             <Pin Id="PdbUp2rIes3NliGAtCbbLU" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="GcSwOeCy6paOQ8h2pleThM" Comment="Color Input" Bounds="274,20,136,15" ShowValueBox="true" isIOBox="true" Value="0.8100002, 0.048597742, 0, 1">
+          <Pad Id="GcSwOeCy6paOQ8h2pleThM" Comment="Color Input" Bounds="775,577,136,15" ShowValueBox="true" isIOBox="true" Value="0.8100002, 0.048597742, 0, 1">
             <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="RGBA" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="CScv9125Nu5LMoKT4qSY21" Comment="Size" Bounds="550,218,43,28" ShowValueBox="true" isIOBox="true" Value="50, 50">
+          <Pad Id="CScv9125Nu5LMoKT4qSY21" Comment="Size" Bounds="1051,775,43,28" ShowValueBox="true" isIOBox="true" Value="50, 50">
             <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector2" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="K1wevcyNAaFLhLBG5fUAX5" Comment="Position" Bounds="1945,66,35,43" ShowValueBox="true" isIOBox="true" Value="4.91, 2.93, -0.85">
+          <Pad Id="K1wevcyNAaFLhLBG5fUAX5" Comment="Position" Bounds="2446,623,35,43" ShowValueBox="true" isIOBox="true" Value="4.91, 2.93, -0.85">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="K0B1Tul1MYiNDRGsDDafkB" Comment="Target" Bounds="2092,84,35,43" ShowValueBox="true" isIOBox="true" Value="0.02, 0.38, -1.43">
+          <Pad Id="K0B1Tul1MYiNDRGsDDafkB" Comment="Target" Bounds="2593,641,35,43" ShowValueBox="true" isIOBox="true" Value="0.02, 0.38, -1.43">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="RYWplPW2LOuMXo0ThJtKbd" Comment="Angle" Bounds="2246,90,35,15" ShowValueBox="true" isIOBox="true" Value="0.24">
+          <Pad Id="RYWplPW2LOuMXo0ThJtKbd" Comment="Angle" Bounds="2747,647,35,15" ShowValueBox="true" isIOBox="true" Value="0.24">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="UN5KnHNqTbXOOQsI8u8wIW" Comment="Range" Bounds="2239,34,35,15" ShowValueBox="true" isIOBox="true" Value="14">
+          <Pad Id="UN5KnHNqTbXOOQsI8u8wIW" Comment="Range" Bounds="2740,591,35,15" ShowValueBox="true" isIOBox="true" Value="14">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="2011,179,245,19" Id="IdIJ0ru7N1ZPUdgrRXDkFV">
+          <Node Bounds="2512,736,245,19" Id="IdIJ0ru7N1ZPUdgrRXDkFV">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SpotLight" />
@@ -284,17 +284,17 @@
             <Pin Id="ViutrhSFkO2OxwT2dlUOAO" Name="Enabled" Kind="InputPin" />
             <Pin Id="Gg04cZb2IiSPEvVCMD31iA" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="IHsV9wkKOFjPMNlRMHhjsR" Comment="Target" Bounds="2171,240,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0.89, 0">
+          <Pad Id="IHsV9wkKOFjPMNlRMHhjsR" Comment="Target" Bounds="2672,797,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0.89, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="A7ttBVdCgYQLRRavgbBKUd" Comment="Position" Bounds="2053,241,35,43" ShowValueBox="true" isIOBox="true" Value="-1.54, 4.84, -3.85">
+          <Pad Id="A7ttBVdCgYQLRRavgbBKUd" Comment="Position" Bounds="2554,798,35,43" ShowValueBox="true" isIOBox="true" Value="-1.54, 4.84, -3.85">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1077,415,145,19" Id="NrO12MrnIA3MQ40FVGGYGR">
+          <Node Bounds="1578,972,145,19" Id="NrO12MrnIA3MQ40FVGGYGR">
             <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Background" />
@@ -309,7 +309,7 @@
             <Pin Id="OnBoRvfPKmXLUzX92s5mwj" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="OKcmgSW4pmLMcYkcgjPG2D" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1097,371,105,19" Id="SAfV1SAA7HwLpIH1EBaBMy">
+          <Node Bounds="1598,928,105,19" Id="SAfV1SAA7HwLpIH1EBaBMy">
             <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FileTexture" />
@@ -324,17 +324,17 @@
             <Pin Id="C8O4MkyGrJDQZKVaPui3Cz" Name="Is Loading" Kind="OutputPin" />
             <Pin Id="PIGzOcDCp1oM5X2f21KEz7" Name="Already Loaded" Kind="OutputPin" />
           </Node>
-          <Pad Id="JQLP9vqan50MevPKfVlyaV" Comment="Softness" Bounds="2151,-122,35,15" ShowValueBox="true" isIOBox="true" Value="0.08">
+          <Pad Id="JQLP9vqan50MevPKfVlyaV" Comment="Softness" Bounds="2652,435,35,15" ShowValueBox="true" isIOBox="true" Value="0.08">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="OtMtuXZR2JhMvcshIaHkca" Comment="Intensity" Bounds="1670,-25,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
+          <Pad Id="OtMtuXZR2JhMvcshIaHkca" Comment="Intensity" Bounds="2171,532,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1529,-122,205,19" Id="SXGTaJM7BrYL4tavrOtcJv">
+          <Node Bounds="2030,435,205,19" Id="SXGTaJM7BrYL4tavrOtcJv">
             <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Wanderer (3D)" />
@@ -352,17 +352,17 @@
             <Pin Id="Nw2lhb4GddkOrZLTGMSwAi" Name="Walk" Kind="InputPin" />
             <Pin Id="Tkk8BL0XxElOe65hx2AMIM" Name="Position" Kind="OutputPin" />
           </Node>
-          <Pad Id="HE4aJK8pRSoOr7d1AxRRKe" Comment="Center" Bounds="1531,-203,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1.98, 0">
+          <Pad Id="HE4aJK8pRSoOr7d1AxRRKe" Comment="Center" Bounds="2032,354,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1.98, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="MjpgpdxUoXFNJyEl9jxzfj" Comment="Width" Bounds="1606,-196,35,43" ShowValueBox="true" isIOBox="true" Value="5, 2, 5">
+          <Pad Id="MjpgpdxUoXFNJyEl9jxzfj" Comment="Width" Bounds="2107,361,35,43" ShowValueBox="true" isIOBox="true" Value="5, 2, 5">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1652,162,205,19" Id="AgtZgfaPhUmQGdv82q1MxQ">
+          <Node Bounds="2153,719,205,19" Id="AgtZgfaPhUmQGdv82q1MxQ">
             <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Wanderer (3D)" />
@@ -380,27 +380,27 @@
             <Pin Id="R3pfAx3hMqiPkQI83e03Q3" Name="Walk" Kind="InputPin" />
             <Pin Id="ElrGqxZMH8bL2PcdjdAHy0" Name="Position" Kind="OutputPin" />
           </Node>
-          <Pad Id="SftQXVfzYiuNT08b8eHXB8" Comment="Center" Bounds="1625,74,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1.96, 0">
+          <Pad Id="SftQXVfzYiuNT08b8eHXB8" Comment="Center" Bounds="2126,631,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1.96, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="Lyj0yaEj85kL931y2E8WOO" Comment="Width" Bounds="1699,102,35,43" ShowValueBox="true" isIOBox="true" Value="5, 2, 5">
+          <Pad Id="Lyj0yaEj85kL931y2E8WOO" Comment="Width" Bounds="2200,659,35,43" ShowValueBox="true" isIOBox="true" Value="5, 2, 5">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="DVy8MIoZE3tLipwOpNhIfR" Comment="Target" Bounds="1703,215,35,43" ShowValueBox="true" isIOBox="true" Value="1, 0, -1">
+          <Pad Id="DVy8MIoZE3tLipwOpNhIfR" Comment="Target" Bounds="2204,772,35,43" ShowValueBox="true" isIOBox="true" Value="1, 0, -1">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="Ev9UXVqxDQdMMlw5JtrWfP" Comment="Smoothing" Bounds="1761,-198,35,15" ShowValueBox="true" isIOBox="true" Value="5">
+          <Pad Id="Ev9UXVqxDQdMMlw5JtrWfP" Comment="Smoothing" Bounds="2262,359,35,15" ShowValueBox="true" isIOBox="true" Value="5">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="271,215,56,19" Id="VerhK9SZEzrPq9aa9FATjb">
+          <Node Bounds="772,772,56,19" Id="VerhK9SZEzrPq9aa9FATjb">
             <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="4026531856" Name="RGBA" />
@@ -410,7 +410,7 @@
             <Pin Id="SzgyG4cPbInO0O5h0yYLZG" Name="Alpha" Kind="InputPin" DefaultValue="1" />
             <Pin Id="HXYxhms6g5NLb7arQhYgAs" Name="Output" Kind="StateOutputPin" />
           </Node>
-          <Node Bounds="321,44,45,19" Id="KUVDUim28zNQCqmqzpYmeU">
+          <Node Bounds="822,601,45,19" Id="KUVDUim28zNQCqmqzpYmeU">
             <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
@@ -422,7 +422,7 @@
             <Pin Id="MhlJW1CBMrxONj6kJ4MEb9" Name="On New Cycle" Kind="OutputPin" />
             <Pin Id="AuH52bGdAE9QVrNjxbufNH" Name="Cycles" Kind="OutputPin" />
           </Node>
-          <Node Bounds="329,72,58,19" Id="VfTbSgZsqzYMJb4IT4peRn">
+          <Node Bounds="830,629,58,19" Id="VfTbSgZsqzYMJb4IT4peRn">
             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="SineWave" />
@@ -430,7 +430,7 @@
             <Pin Id="IH3hZe8WZwuO0nuvXuAeBb" Name="Phase" Kind="InputPin" />
             <Pin Id="ToOEYQ2IpnPPqXf14xl2gE" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="322,103,25,19" Id="Tv9MsjL1QaXNR0sQzt4xMn">
+          <Node Bounds="823,660,25,19" Id="Tv9MsjL1QaXNR0sQzt4xMn">
             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="+" />
@@ -439,7 +439,7 @@
             <Pin Id="TUdy0BDBmbZL5WJYyTbmUS" Name="Input 2" Kind="InputPin" DefaultValue="1" />
             <Pin Id="GuKDOheAjILLn4J5ZLHrLo" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="323,131,25,19" Id="OyYsqKVgjZjNANIWFxP5hT">
+          <Node Bounds="824,688,25,19" Id="OyYsqKVgjZjNANIWFxP5hT">
             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="*" />
@@ -448,14 +448,14 @@
             <Pin Id="JioVfEsoR0oLo6FXLVBHrR" Name="Input 2" Kind="InputPin" DefaultValue="0.5" />
             <Pin Id="Nnd11E76FhbN07IrgFQEhr" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="RhY6NtdVGSSNseQInEf1FS" Comment="Alpha" Bounds="342,207,20,68" ShowValueBox="true" isIOBox="true">
+          <Pad Id="RhY6NtdVGSSNseQInEf1FS" Comment="Alpha" Bounds="843,764,20,68" ShowValueBox="true" isIOBox="true">
             <p:ValueBoxSettings>
               <p:maximum p:Type="Single">1</p:maximum>
               <p:minimum p:Type="Single">0</p:minimum>
               <p:showslider p:Type="Boolean">true</p:showslider>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="LtikeCWmiNlO2xF1HR5kb6" Comment="Overlay BG" Bounds="1226,-92,93,82" ShowValueBox="true" isIOBox="true" Value="False">
+          <Pad Id="LtikeCWmiNlO2xF1HR5kb6" Comment="Overlay BG" Bounds="1727,465,93,82" ShowValueBox="true" isIOBox="true" Value="False">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -465,7 +465,7 @@
               <p:fontsize p:Type="Int32">25</p:fontsize>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="1155,162,37,19" Id="FRt3v5GGyh5NdwTsJ6wu1U">
+          <Node Bounds="1654,670,37,19" Id="FRt3v5GGyh5NdwTsJ6wu1U">
             <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -473,7 +473,7 @@
             <Pin Id="EWoNMedmYrhLbZH8i2hXly" Name="Input" Kind="StateInputPin" />
             <Pin Id="MMC0lrjH9nHQMzkxFscg8x" Name="Output" Kind="StateOutputPin" />
           </Node>
-          <Node Bounds="210,343,86,19" Id="D5c4pRzixFKOOZJZc5EpRn">
+          <Node Bounds="711,900,86,19" Id="D5c4pRzixFKOOZJZc5EpRn">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
@@ -485,7 +485,7 @@
             <Pin Id="ED9KyHuvqOxQX3WhmvRzHD" Name="Enabled" Kind="InputPin" />
             <Pin Id="L5KCskD6y0AL4SUAnNtqtD" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="-12,340,105,19" Id="GqCMYssFWLrNuPDUrbUwZH">
+          <Node Bounds="489,897,105,19" Id="GqCMYssFWLrNuPDUrbUwZH">
             <p:NodeReference LastCategoryFullName="ShadowCatcher" LastDependency="VL.ShadowCatcher.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="ShadowCatcher" />
@@ -498,7 +498,7 @@
             <Pin Id="R4DwocibzfwM3gblCdr0ie" Name="Enabled" Kind="InputPin" />
             <Pin Id="T0feYkj4NlvQUle455rx75" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="28,253,85,19" Id="NokpFLOzWqgLdYO9U9qcSX">
+          <Node Bounds="529,810,85,19" Id="NokpFLOzWqgLdYO9U9qcSX">
             <p:NodeReference LastCategoryFullName="Stride.Models.Meshes" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="TeapotMesh" />
@@ -510,7 +510,7 @@
             <Pin Id="MEgTluqDy1mQaAURAfppg4" Name="Number Of Texture Coordinates" Kind="InputPin" />
             <Pin Id="NqfsoIjLTp2NvNFc17zzlt" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="172,537,105,19" Id="IQELxTg8dV5MN8ljBbaYCV">
+          <Node Bounds="673,1094,105,19" Id="IQELxTg8dV5MN8ljBbaYCV">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -524,7 +524,7 @@
             <Pin Id="LEQUUgUdODDQXu0KGUrL3b" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="LAQmbCYrppPLAeOagCp3q3" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="722,-93,80,19" Id="TRv2YbLJf46OBRYQ4WgpvG">
+          <Node Bounds="1345,469,80,19" Id="TRv2YbLJf46OBRYQ4WgpvG">
             <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -538,12 +538,12 @@
             <Pin Id="FjHpbreIvtmMP67eOCEcB9" Name="Translation" Kind="InputPin" />
             <Pin Id="MIGcwRcltQ6LP3CU2j4YY8" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="RCW5hgNu1qgNHmT8lguKwG" Comment="Translation" Bounds="823,-149,35,43" ShowValueBox="true" isIOBox="true" Value="0.35, 0.86, -3.44">
+          <Pad Id="RCW5hgNu1qgNHmT8lguKwG" Comment="Translation" Bounds="1446,413,35,43" ShowValueBox="true" isIOBox="true" Value="0.35, 0.86, -3.44">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="781,555,145,19" Id="KUmFjRRxwHxQZcVvZkeX3r">
+          <Node Bounds="1282,1112,145,19" Id="KUmFjRRxwHxQZcVvZkeX3r">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -559,12 +559,12 @@
             <Pin Id="QQEELVdBnDCNIr1Hwrkin6" Name="Enabled" Kind="InputPin" />
             <Pin Id="Tw2DIJETS1mNrmbLjvh3SF" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="BaXd59LhcpkMYkrQQ2JQ85" Comment="Scaling" Bounds="687,-215,35,43" ShowValueBox="true" isIOBox="true" Value="2.96, 2.96, 2.96">
+          <Pad Id="BaXd59LhcpkMYkrQQ2JQ85" Comment="Scaling" Bounds="1310,347,35,43" ShowValueBox="true" isIOBox="true" Value="2.96, 2.96, 2.96">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="GdG4gDvAmAkPeylIJu0FkH" Comment="Walk" Bounds="1785,-139,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+          <Pad Id="GdG4gDvAmAkPeylIJu0FkH" Comment="Walk" Bounds="2286,418,35,35" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -573,7 +573,7 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="839,172,165,19" Id="GUgG3Q7tQlNO9X6qIZcEct">
+          <Node Bounds="1340,729,165,19" Id="GUgG3Q7tQlNO9X6qIZcEct">
             <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Teapot" />
@@ -589,7 +589,7 @@
             <Pin Id="RBKyp2z3Xk9M0LtCIoNupc" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="V6b6YhteyHRNtbGsiK8eot" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="QBb1JCKrw43P4Y7BY1fLIx" Comment="Is Shadow Caster" Bounds="921,145,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+          <Pad Id="QBb1JCKrw43P4Y7BY1fLIx" Comment="Is Shadow Caster" Bounds="1422,702,35,15" ShowValueBox="true" isIOBox="true" Value="False">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -598,7 +598,7 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="NIGZ628EnLdL7lxY3VwM5b" Bounds="-60,-473,390,69" ShowValueBox="true" isIOBox="true" Value="2. Render ShadowCatcher using Compositor and GetShadowParameters.">
+          <Pad Id="NIGZ628EnLdL7lxY3VwM5b" Bounds="441,84,390,69" ShowValueBox="true" isIOBox="true" Value="2. Render ShadowCatcher using Compositor and GetShadowParameters.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -607,14 +607,14 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Overlay Id="B1vQLw8roSnLPjuPAsxOoP" Name="Shadow Catcher" Bounds="-67,-38,584,530">
+          <Overlay Id="B1vQLw8roSnLPjuPAsxOoP" Name="Shadow Catcher" Bounds="434,519,584,530">
             <p:ColorIndex p:Type="Int32">6</p:ColorIndex>
           </Overlay>
-          <Overlay Id="TCQN82TEDJ2LI4iwLcqwUa" Name="Scene" Bounds="612,10,646,589" />
-          <Overlay Id="FBFCpxtoSeOPgIm2DowFB7" Name="Lights" Bounds="1466,-268,974,862">
+          <Overlay Id="TCQN82TEDJ2LI4iwLcqwUa" Name="Scene" Bounds="1113,567,646,589" />
+          <Overlay Id="FBFCpxtoSeOPgIm2DowFB7" Name="Lights" Bounds="1967,289,974,862">
             <p:ColorIndex p:Type="Int32">5</p:ColorIndex>
           </Overlay>
-          <Pad Id="QjOMJD08BEGNUdzgGwe59i" Bounds="-488,99,390,69" ShowValueBox="true" isIOBox="true" Value="Use ShadowCatcher to draw all objects that you wish to receive a transparent shadow.">
+          <Pad Id="QjOMJD08BEGNUdzgGwe59i" Bounds="13,656,390,69" ShowValueBox="true" isIOBox="true" Value="Use ShadowCatcher to draw all objects that you wish to receive a transparent shadow.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -623,7 +623,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="ViAvH5PGswYNq8O6ijji2K" Bounds="-488,186,390,69" ShowValueBox="true" isIOBox="true" Value="Only direct shadows from shadow mapping are rendered here.">
+          <Pad Id="ViAvH5PGswYNq8O6ijji2K" Bounds="13,743,390,69" ShowValueBox="true" isIOBox="true" Value="Only direct shadows from shadow mapping are rendered here.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -632,7 +632,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="632,311,427,177" Id="JdzvwQNb5UNLHlF1ILZnDO">
+          <Node Bounds="1133,868,427,177" Id="JdzvwQNb5UNLHlF1ILZnDO">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -642,7 +642,7 @@
               <Patch Id="DRxjlWPDnYGLMUblMRbzTj" Name="Create" ManuallySortedPins="true" />
               <Patch Id="TwYikpNKR8VMBuPoWo0O0r" Name="Update" ManuallySortedPins="true" />
               <Patch Id="MzWkpxT3uYjQSTSWjPdJkr" Name="Dispose" ManuallySortedPins="true" />
-              <Node Bounds="644,339,165,19" Id="D2Qb5diMTAfLPAUL8ufPKR">
+              <Node Bounds="1145,896,165,19" Id="D2Qb5diMTAfLPAUL8ufPKR">
                 <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Box" />
@@ -658,7 +658,7 @@
                 <Pin Id="SKFYffW2MSpLjWUV4X2ek4" Name="Enabled" Kind="InputPin" DefaultValue="True" />
                 <Pin Id="EmKxcvIoWlaPe4UIs2MpCd" Name="Entity" Kind="OutputPin" />
               </Node>
-              <Node Bounds="742,405,305,19" Id="LhU6QW5YYDYO1PLXF1zZQ6">
+              <Node Bounds="1243,962,305,19" Id="LhU6QW5YYDYO1PLXF1zZQ6">
                 <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="Cylinder" />
@@ -681,7 +681,7 @@
                 <Pin Id="G5orQkWPWdJPTYexpVsiUE" Name="Enabled" Kind="InputPin" />
                 <Pin Id="GnAlxay4kcKMfRYrGPhExQ" Name="Entity" Kind="OutputPin" />
               </Node>
-              <Node Bounds="702,446,85,19" Id="EYWIHvyV61xNavmJAmZMFi">
+              <Node Bounds="1203,1003,85,19" Id="EYWIHvyV61xNavmJAmZMFi">
                 <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -694,7 +694,7 @@
                 <Pin Id="EdPlijI3016M97pqf0X5st" Name="Enabled" Kind="InputPin" />
                 <Pin Id="BhiAaqVtlGUOzB0dnnvCJv" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="647,409,58,19" Id="CkP3a76u4z4PRNkSFT4cE3">
+              <Node Bounds="1148,966,58,19" Id="CkP3a76u4z4PRNkSFT4cE3">
                 <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -706,7 +706,7 @@
                 <Pin Id="ACiLiHd2McOLuzVyHFPWzc" Name="Translation" Kind="InputPin" />
                 <Pin Id="EzO0UK7wMVOMPext2787mX" Name="Output" Kind="OutputPin" />
               </Node>
-              <Node Bounds="700,374,46,19" Id="E6XRJQ0MaJPNQDc06erqyj">
+              <Node Bounds="1201,931,46,19" Id="E6XRJQ0MaJPNQDc06erqyj">
                 <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -718,11 +718,11 @@
                 <Pin Id="HMdKmNwB3CSO4CHWCstzSW" Name="Output" Kind="StateOutputPin" />
               </Node>
             </Patch>
-            <ControlPoint Id="JAN26II04IZM1UfmjKOb9p" Bounds="705,482" Alignment="Bottom" />
+            <ControlPoint Id="JAN26II04IZM1UfmjKOb9p" Bounds="1206,1039" Alignment="Bottom" />
             <Pin Id="DrALkzCDmOiP2Q5Tpwzfjd" Name="Break" Kind="OutputPin" />
-            <ControlPoint Id="HCFH4nsLsz9PPMEytfrx3V" Bounds="742,317" Alignment="Top" />
+            <ControlPoint Id="HCFH4nsLsz9PPMEytfrx3V" Bounds="1243,874" Alignment="Top" />
           </Node>
-          <Node Bounds="683,505,65,19" Id="Jn7E8ZEZS4SNCitRmyujl7">
+          <Node Bounds="1184,1062,65,19" Id="Jn7E8ZEZS4SNCitRmyujl7">
             <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
@@ -734,7 +734,7 @@
             <Pin Id="Erz7jVrlMcqNxn3xAcko1x" Name="Enabled" Kind="InputPin" />
             <Pin Id="BiX4UxMeQmfL2FtcjrBCse" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="741,275,85,19" Id="GfbeRMUpOJlPLGTg5wa9f3">
+          <Node Bounds="1242,832,85,19" Id="GfbeRMUpOJlPLGTg5wa9f3">
             <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
@@ -746,12 +746,12 @@
             <Pin Id="Tk56KqQzb6gOp2CwsVvZUS" Name="Count" Kind="InputPin" DefaultValue="2" />
             <Pin Id="TsgJYK3xnGMPq97YHywaO6" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="OcQDa17QFn4Lry9UlDb5oG" Comment="Rotation" Bounds="756,-180,35,43" ShowValueBox="true" isIOBox="true" Value="0, -0.66, 0">
+          <Pad Id="OcQDa17QFn4Lry9UlDb5oG" Comment="Rotation" Bounds="1379,382,35,43" ShowValueBox="true" isIOBox="true" Value="0, -0.66, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="323,163,79,19" Id="O0BVolLwg4nNdmkLDKxbiT">
+          <Node Bounds="824,720,79,19" Id="O0BVolLwg4nNdmkLDKxbiT">
             <p:NodeReference LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="CubicEaseOut" />
@@ -759,7 +759,7 @@
             <Pin Id="P4BRtNFyrHPMnxlhjiHhJC" Name="X" Kind="InputPin" />
             <Pin Id="K5eLDg1nIgRNUnMXW8ttg9" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1740,425,185,19" Id="Bb1Lp2UvWp4M9H9nyhjaQP">
+          <Node Bounds="2241,982,185,19" Id="Bb1Lp2UvWp4M9H9nyhjaQP">
             <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PointLight" />
@@ -776,22 +776,22 @@
             <Pin Id="LtCUiGFo8W4Ll8zjhc9Yh4" Name="Enabled" Kind="InputPin" />
             <Pin Id="KZcVH4ouoWBPVhPrDJb6p5" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Pad Id="GmMXXKTfyeFOGqWS0CzQPS" Comment="Radius" Bounds="1824,375,35,15" ShowValueBox="true" isIOBox="true" Value="7.77">
+          <Pad Id="GmMXXKTfyeFOGqWS0CzQPS" Comment="Radius" Bounds="2325,932,35,15" ShowValueBox="true" isIOBox="true" Value="7.77">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="LQap6NTpSLPLV8EUPNcXxc" Comment="Intensity" Bounds="1756,351,35,15" ShowValueBox="true" isIOBox="true" Value="7.26">
+          <Pad Id="LQap6NTpSLPLV8EUPNcXxc" Comment="Intensity" Bounds="2257,908,35,15" ShowValueBox="true" isIOBox="true" Value="7.26">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="EMSp6CMW1fjNyh8TxWtnsO" Comment="Position" Bounds="1662,355,35,43" ShowValueBox="true" isIOBox="true" Value="0.1, 3.02, 0.74">
+          <Pad Id="EMSp6CMW1fjNyh8TxWtnsO" Comment="Position" Bounds="2163,912,35,43" ShowValueBox="true" isIOBox="true" Value="0.1, 3.02, 0.74">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="VPs2IvuAoPKQDi46CVPXiA" Comment="Light Attenuation" Bounds="162,-308,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+          <Pad Id="VPs2IvuAoPKQDi46CVPXiA" Comment="Light Attenuation" Bounds="663,249,35,35" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -800,7 +800,7 @@
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="MXBAL3btUDdOGGWLYunh2Z" Bounds="209,-281,341,67" ShowValueBox="true" isIOBox="true" Value="Apply SpotLight and PointLight attenuation with distance and angle.">
+          <Pad Id="MXBAL3btUDdOGGWLYunh2Z" Bounds="710,276,341,67" ShowValueBox="true" isIOBox="true" Value="Apply SpotLight and PointLight attenuation with distance and angle.">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -809,7 +809,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="JXEN6tFsiOPNso2cVGN4Wn" Bounds="209,-212,361,143" ShowValueBox="true" isIOBox="true" Value="However, when SpotLight and DirectionalLight are used together, artifacts will occur if Light Attenuation is disabled. This is due to the interference of adjacent ShadowMap Atlas">
+          <Pad Id="JXEN6tFsiOPNso2cVGN4Wn" Bounds="710,345,361,143" ShowValueBox="true" isIOBox="true" Value="However, when SpotLight and DirectionalLight are used together, artifacts will occur if Light Attenuation is disabled. This is due to the interference of adjacent ShadowMap Atlas">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -818,7 +818,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Node Bounds="1868,393,125,19" Id="KpcDwJ5hvnyNYNzcycFGoz">
+          <Node Bounds="2369,950,125,19" Id="KpcDwJ5hvnyNYNzcycFGoz">
             <p:NodeReference LastCategoryFullName="Stride.Lights.ShadowMaps" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LightPointShadowMap" />
@@ -832,22 +832,22 @@
             <Pin Id="UsVkOX5dJkgPIKLmBhYEje" Name="Enabled" Kind="InputPin" DefaultValue="True" />
             <Pin Id="TmEdbqIW0LANqdR9NcN8ld" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="RrRAdDz22dKNLSsmhyh9bn" Comment="Range" Bounds="2251,246,35,15" ShowValueBox="true" isIOBox="true" Value="14.15">
+          <Pad Id="RrRAdDz22dKNLSsmhyh9bn" Comment="Range" Bounds="2752,803,35,15" ShowValueBox="true" isIOBox="true" Value="14.15">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="CiSzo3rBEDvLsUhobFdJdC" Comment="Angle" Bounds="2274,273,35,15" ShowValueBox="true" isIOBox="true" Value="0.3">
+          <Pad Id="CiSzo3rBEDvLsUhobFdJdC" Comment="Angle" Bounds="2775,830,35,15" ShowValueBox="true" isIOBox="true" Value="0.3">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="JoMLB4R15RkMhdtxV0OwF2" Comment="Translation" Bounds="1024,171,35,43" ShowValueBox="true" isIOBox="true" Value="0, -0.0006, 0">
+          <Pad Id="JoMLB4R15RkMhdtxV0OwF2" Comment="Translation" Bounds="1529,732,35,43" ShowValueBox="true" isIOBox="true" Value="0, -0.0006, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="1799,224,185,19" Id="MXaxaHogrpLNkWOusdFDBO">
+          <Node Bounds="2300,781,185,19" Id="MXaxaHogrpLNkWOusdFDBO">
             <p:NodeReference LastCategoryFullName="Stride.Lights.ShadowMaps" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LightDirectionalShadowMap" />
@@ -864,7 +864,7 @@
             <Pin Id="S2E4AbfXHJkPl6pdpoaQQg" Name="Enabled" Kind="InputPin" />
             <Pin Id="DYVkg2E1m5PPz46YFHiG9q" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="1837,190,151,19" Id="HMVpvmcU5HSMPM4M96nw8R">
+          <Node Bounds="2338,747,151,19" Id="HMVpvmcU5HSMPM4M96nw8R">
             <p:NodeReference LastCategoryFullName="Stride.Lights.ShadowMaps" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="LightShadowMapFilterTypePcf" />
@@ -872,17 +872,17 @@
             <Pin Id="SM5GzcEqFpYNpkyh5XzLH1" Name="Filter Size" Kind="InputPin" DefaultValue="Filter7x7" />
             <Pin Id="SzHo29FGmPVQKlt5PaSUms" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="VON7P4TnA6GL40GjtviY6Z" Comment="Local Offset" Bounds="116,209,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0, 0">
+          <Pad Id="VON7P4TnA6GL40GjtviY6Z" Comment="Local Offset" Bounds="617,766,35,43" ShowValueBox="true" isIOBox="true" Value="0, 0, 0">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="JnV6DG2SKeIPKMbwRsX2me" Comment="Speed" Bounds="1705,-184,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
+          <Pad Id="JnV6DG2SKeIPKMbwRsX2me" Comment="Speed" Bounds="2206,373,35,15" ShowValueBox="true" isIOBox="true" Value="0.02">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="HKL3bTUWa3lP5BXMkCa6sX" Comment="Normal Offset" Bounds="84,301,45,15" ShowValueBox="true" isIOBox="true" Value="0.001">
+          <Pad Id="HKL3bTUWa3lP5BXMkCa6sX" Comment="Normal Offset" Bounds="585,858,45,15" ShowValueBox="true" isIOBox="true" Value="0.001">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -891,6 +891,7 @@
               <p:stepsize p:Type="Single">0.01</p:stepsize>
             </p:ValueBoxSettings>
           </Pad>
+          <ControlPoint Id="SNXW6lUH5rOMQJeRwJhqH4" Bounds="497,576" />
         </Canvas>
         <Patch Id="AAGnmTkDUlyLLCeemYexUS" Name="Create" />
         <Patch Id="Hed4moB1HBIPKEKGLFwLzt" Name="Update" />
@@ -935,7 +936,7 @@
         <Link Id="QTsblduw8wzNt6qwf4ylZz" Ids="OKvPoreXgvbNARyrwgGGlx,Tz9u9eVy4yGQIsuRLDUVKK" />
         <Link Id="TyBjDy7xsJ6QKm2vDFK13h" Ids="NqfsoIjLTp2NvNFc17zzlt,QlvHA9CnNRnLefU7meFa2f" />
         <Link Id="UoNcAANMgquQExGHUQUtW1" Ids="HXYxhms6g5NLb7arQhYgAs,K23xhI6fieRONeH9VNVc07" />
-        <Link Id="Vq6nh2nfJjuL9PNK0jMeeN" Ids="MIGcwRcltQ6LP3CU2j4YY8,BDZeBGGnaFJNFKYZZIl0TB" />
+        <Link Id="Vq6nh2nfJjuL9PNK0jMeeN" Ids="MIGcwRcltQ6LP3CU2j4YY8,SNXW6lUH5rOMQJeRwJhqH4,BDZeBGGnaFJNFKYZZIl0TB" />
         <Link Id="DMsyoydr2d5QUGgVLzDWWu" Ids="RCW5hgNu1qgNHmT8lguKwG,FjHpbreIvtmMP67eOCEcB9" />
         <Link Id="Pwc3UYbgejjLREpvyKRDlD" Ids="BaXd59LhcpkMYkrQQ2JQ85,HO2wcgBoIJxLMlYAWYRDms" />
         <Link Id="CwEqN99cH4JLQNNdZNBjgw" Ids="GdG4gDvAmAkPeylIJu0FkH,Nw2lhb4GddkOrZLTGMSwAi" />


### PR DESCRIPTION
This PR improves two things:
* The shadow data is retrieved in the same frame in the draw call before drawing the shadow catcher
* The custom scene nodes aren't necessary because the show maps can be retrieved from the RenderContext in the draw call too

